### PR TITLE
Add SO-101 robot support with Feetech STS3215 motor driver

### DIFF
--- a/src/robopy/kinematics/__init__.py
+++ b/src/robopy/kinematics/__init__.py
@@ -1,0 +1,17 @@
+"""Kinematics module for robopy: FK and IK for 5-DOF robot arms."""
+
+from .chain import KinematicChain, RevoluteJoint
+from .ee_pose import EEPose
+from .ik_solver import IKConfig, IKResult, IKSolver
+from .robot_chains import koch_chain, so101_chain
+
+__all__ = [
+    "EEPose",
+    "IKConfig",
+    "IKResult",
+    "IKSolver",
+    "KinematicChain",
+    "RevoluteJoint",
+    "koch_chain",
+    "so101_chain",
+]

--- a/src/robopy/kinematics/chain.py
+++ b/src/robopy/kinematics/chain.py
@@ -1,0 +1,141 @@
+"""Kinematic chain with forward kinematics and numerical Jacobian."""
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .transforms import pose_from_matrix, rot_x, rot_y, rot_z
+
+_ROT_FUNCS = {"x": rot_x, "y": rot_y, "z": rot_z}
+
+
+@dataclass(frozen=True)
+class RevoluteJoint:
+    """A single revolute joint in the kinematic chain.
+
+    Attributes:
+        name: Joint name (e.g., "shoulder_pan").
+        parent_to_joint: 4x4 static transform from parent frame to this joint's
+            rotation center (before any rotation is applied).
+        axis: Rotation axis as a string: "x", "y", or "z".
+        lower_limit_rad: Minimum joint angle in radians.
+        upper_limit_rad: Maximum joint angle in radians.
+    """
+
+    name: str
+    parent_to_joint: NDArray[np.float64]
+    axis: str
+    lower_limit_rad: float
+    upper_limit_rad: float
+
+    def __post_init__(self) -> None:
+        if self.axis not in _ROT_FUNCS:
+            raise ValueError(f"axis must be 'x', 'y', or 'z', got '{self.axis}'")
+
+
+class KinematicChain:
+    """Forward kinematics and numerical Jacobian for a serial revolute chain.
+
+    The chain is a sequence of :class:`RevoluteJoint` objects followed by a
+    fixed transform from the last joint frame to the end-effector frame.
+    """
+
+    def __init__(
+        self,
+        joints: List[RevoluteJoint],
+        ee_fixed_transform: NDArray[np.float64],
+    ) -> None:
+        self._joints = list(joints)
+        self._ee_fixed = np.array(ee_fixed_transform, dtype=np.float64)
+        self._n_joints = len(self._joints)
+
+    @property
+    def n_joints(self) -> int:
+        return self._n_joints
+
+    @property
+    def joint_names(self) -> List[str]:
+        return [j.name for j in self._joints]
+
+    @property
+    def lower_limits_rad(self) -> NDArray[np.float64]:
+        return np.array([j.lower_limit_rad for j in self._joints])
+
+    @property
+    def upper_limits_rad(self) -> NDArray[np.float64]:
+        return np.array([j.upper_limit_rad for j in self._joints])
+
+    def forward_kinematics_matrix(
+        self, joint_angles_rad: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Compute the 4x4 homogeneous transform from base to end-effector.
+
+        Args:
+            joint_angles_rad: (n_joints,) array of joint angles in radians.
+
+        Returns:
+            4x4 homogeneous transformation matrix.
+        """
+        if len(joint_angles_rad) != self._n_joints:
+            raise ValueError(
+                f"Expected {self._n_joints} joint angles, got {len(joint_angles_rad)}"
+            )
+
+        T = np.eye(4)
+        for i, joint in enumerate(self._joints):
+            rot_fn = _ROT_FUNCS[joint.axis]
+            T = T @ joint.parent_to_joint @ rot_fn(float(joint_angles_rad[i]))
+        T = T @ self._ee_fixed
+        return T
+
+    def forward_kinematics(
+        self, joint_angles_rad: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Compute end-effector pose as (x, y, z, pitch, roll).
+
+        Args:
+            joint_angles_rad: (n_joints,) array of joint angles in radians.
+
+        Returns:
+            (5,) array [x, y, z, pitch, roll].
+        """
+        T = self.forward_kinematics_matrix(joint_angles_rad)
+        return pose_from_matrix(T)
+
+    def jacobian(
+        self, joint_angles_rad: NDArray[np.float64], delta: float = 1e-6
+    ) -> NDArray[np.float64]:
+        """Numerical Jacobian of the 5-DOF pose w.r.t. joint angles.
+
+        Uses central finite differences for O(delta^2) accuracy.
+
+        Returns:
+            (5, n_joints) Jacobian matrix.
+        """
+        J = np.zeros((5, self._n_joints))
+
+        for i in range(self._n_joints):
+            q_plus = joint_angles_rad.copy()
+            q_minus = joint_angles_rad.copy()
+            q_plus[i] += delta
+            q_minus[i] -= delta
+
+            pose_plus = self.forward_kinematics(q_plus)
+            pose_minus = self.forward_kinematics(q_minus)
+
+            diff = pose_plus - pose_minus
+            # Wrap angular components to [-pi, pi]
+            for k in (3, 4):
+                diff[k] = (diff[k] + np.pi) % (2 * np.pi) - np.pi
+
+            J[:, i] = diff / (2 * delta)
+
+        return J
+
+    def clamp_to_limits(
+        self, joint_angles_rad: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Clamp joint angles to their limits."""
+        return np.clip(joint_angles_rad, self.lower_limits_rad, self.upper_limits_rad)

--- a/src/robopy/kinematics/ee_pose.py
+++ b/src/robopy/kinematics/ee_pose.py
@@ -1,0 +1,42 @@
+"""End-effector pose representation for 5-DOF robots."""
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class EEPose:
+    """5-DOF end-effector pose.
+
+    Attributes:
+        x: End-effector X position in meters.
+        y: End-effector Y position in meters.
+        z: End-effector Z position in meters.
+        pitch: Rotation about the Y-axis in radians.
+        roll: Rotation about the X-axis in radians.
+    """
+
+    x: float
+    y: float
+    z: float
+    pitch: float
+    roll: float
+
+    def to_array(self) -> NDArray[np.float64]:
+        """Return (5,) numpy array [x, y, z, pitch, roll]."""
+        return np.array([self.x, self.y, self.z, self.pitch, self.roll])
+
+    @classmethod
+    def from_array(cls, arr: NDArray[np.float64]) -> "EEPose":
+        """Construct from a (5,) array."""
+        if len(arr) != 5:
+            raise ValueError(f"Expected 5 elements, got {len(arr)}")
+        return cls(
+            x=float(arr[0]),
+            y=float(arr[1]),
+            z=float(arr[2]),
+            pitch=float(arr[3]),
+            roll=float(arr[4]),
+        )

--- a/src/robopy/kinematics/ik_solver.py
+++ b/src/robopy/kinematics/ik_solver.py
@@ -1,0 +1,162 @@
+"""Damped least-squares inverse kinematics solver (numpy only)."""
+
+from dataclasses import dataclass
+from logging import getLogger
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .chain import KinematicChain
+
+logger = getLogger(__name__)
+
+
+@dataclass
+class IKConfig:
+    """Configuration for the IK solver.
+
+    Attributes:
+        max_iterations: Maximum solver iterations.
+        position_tolerance: Convergence threshold for position error (meters).
+        orientation_tolerance: Convergence threshold for orientation error (radians).
+        damping: Damping factor lambda for DLS. Higher = more stable, less accurate.
+        step_scale: Scale factor for each iteration step (0 < step_scale <= 1).
+        position_weight: Weight for position (x, y, z) components in the error.
+        orientation_weight: Weight for orientation (pitch, roll) components.
+        joint_limit_margin_rad: Stay this far inside joint limits.
+    """
+
+    max_iterations: int = 100
+    position_tolerance: float = 1e-4  # 0.1 mm
+    orientation_tolerance: float = 1e-3  # ~0.06 degrees
+    damping: float = 0.05
+    step_scale: float = 0.5
+    position_weight: float = 1.0
+    orientation_weight: float = 0.1
+    joint_limit_margin_rad: float = 0.01  # ~0.57 degrees
+
+
+@dataclass
+class IKResult:
+    """Result from the IK solver.
+
+    Attributes:
+        joint_angles_rad: (n_joints,) solution joint angles in radians.
+        success: Whether the solver converged within tolerance.
+        iterations: Number of iterations used.
+        position_error: Final Euclidean position error in meters.
+        orientation_error: Final orientation error in radians.
+    """
+
+    joint_angles_rad: NDArray[np.float64]
+    success: bool
+    iterations: int
+    position_error: float
+    orientation_error: float
+
+
+class IKSolver:
+    """Damped Least-Squares (Levenberg-Marquardt style) IK solver.
+
+    Uses the formulation::
+
+        dq = J_w^T (J_w J_w^T + lambda^2 I)^{-1} e_w
+
+    where *J_w* is the weighted Jacobian and *e_w* is the weighted task-space
+    error.  The 5x5 linear system is solved with ``np.linalg.solve`` — no
+    scipy required.
+    """
+
+    def __init__(
+        self, chain: KinematicChain, config: IKConfig | None = None
+    ) -> None:
+        self._chain = chain
+        self._config = config or IKConfig()
+
+    @property
+    def config(self) -> IKConfig:
+        return self._config
+
+    def solve(
+        self,
+        target_pose: NDArray[np.float64],
+        initial_angles_rad: NDArray[np.float64],
+    ) -> IKResult:
+        """Solve IK for a target 5-DOF pose.
+
+        Args:
+            target_pose: (5,) array [x, y, z, pitch, roll].
+            initial_angles_rad: (n_joints,) initial guess in radians.
+
+        Returns:
+            IKResult with solution and convergence information.
+        """
+        cfg = self._config
+        q = initial_angles_rad.copy().astype(np.float64)
+
+        W = np.diag([
+            cfg.position_weight,
+            cfg.position_weight,
+            cfg.position_weight,
+            cfg.orientation_weight,
+            cfg.orientation_weight,
+        ])
+
+        lower = self._chain.lower_limits_rad + cfg.joint_limit_margin_rad
+        upper = self._chain.upper_limits_rad - cfg.joint_limit_margin_rad
+
+        for iteration in range(cfg.max_iterations):
+            current_pose = self._chain.forward_kinematics(q)
+            error = target_pose - current_pose
+
+            # Wrap angular errors to [-pi, pi]
+            for k in (3, 4):
+                error[k] = (error[k] + np.pi) % (2 * np.pi) - np.pi
+
+            pos_err = float(np.linalg.norm(error[:3]))
+            ori_err = float(np.linalg.norm(error[3:]))
+
+            if pos_err < cfg.position_tolerance and ori_err < cfg.orientation_tolerance:
+                return IKResult(
+                    joint_angles_rad=q,
+                    success=True,
+                    iterations=iteration + 1,
+                    position_error=pos_err,
+                    orientation_error=ori_err,
+                )
+
+            # Weighted error and Jacobian
+            e_w = W @ error
+            J = self._chain.jacobian(q)
+            J_w = W @ J  # (5, n_joints)
+
+            # DLS: dq = J_w^T (J_w J_w^T + lambda^2 I)^{-1} e_w
+            JJT = J_w @ J_w.T  # (5, 5)
+            damped = JJT + (cfg.damping**2) * np.eye(5)
+            y = np.linalg.solve(damped, e_w)
+            dq = J_w.T @ y
+
+            q = q + cfg.step_scale * dq
+            q = np.clip(q, lower, upper)
+
+        # Did not converge — compute final error
+        current_pose = self._chain.forward_kinematics(q)
+        error = target_pose - current_pose
+        pos_err = float(np.linalg.norm(error[:3]))
+        ori_err = float(np.linalg.norm(error[3:]))
+
+        logger.warning(
+            "IK did not converge after %d iterations. "
+            "Position error: %.6f m, Orientation error: %.6f rad",
+            cfg.max_iterations,
+            pos_err,
+            ori_err,
+        )
+
+        return IKResult(
+            joint_angles_rad=q,
+            success=False,
+            iterations=cfg.max_iterations,
+            position_error=pos_err,
+            orientation_error=ori_err,
+        )

--- a/src/robopy/kinematics/robot_chains.py
+++ b/src/robopy/kinematics/robot_chains.py
@@ -1,0 +1,127 @@
+"""Factory functions creating KinematicChain for each supported robot."""
+
+from .chain import KinematicChain, RevoluteJoint
+from .transforms import translation
+
+
+def so101_chain() -> KinematicChain:
+    """Create the kinematic chain for the SO-101 robot (5-DOF, excluding gripper).
+
+    Parameters are derived from the SO-101 URDF
+    (``SO-ARM100/Simulation/SO101/so101_new_calib.urdf``).
+
+    Joint axes follow the URDF convention:
+        shoulder_pan / wrist_roll → Y-axis rotation,
+        shoulder_lift / elbow_flex / wrist_flex → X-axis rotation.
+    """
+    joints = [
+        RevoluteJoint(
+            name="shoulder_pan",
+            parent_to_joint=translation(0.0388, 0.0, 0.0624),
+            axis="y",
+            lower_limit_rad=-1.91986,  # -110 deg
+            upper_limit_rad=1.91986,  # +110 deg
+        ),
+        RevoluteJoint(
+            name="shoulder_lift",
+            parent_to_joint=translation(-0.0304, -0.0183, -0.0542),
+            axis="x",
+            lower_limit_rad=-1.74533,  # -100 deg
+            upper_limit_rad=1.74533,  # +100 deg
+        ),
+        RevoluteJoint(
+            name="elbow_flex",
+            parent_to_joint=translation(-0.11257, -0.028, 0.0),
+            axis="x",
+            lower_limit_rad=-1.69,  # -96.8 deg
+            upper_limit_rad=1.69,  # +96.8 deg
+        ),
+        RevoluteJoint(
+            name="wrist_flex",
+            parent_to_joint=translation(-0.1349, 0.0052, 0.0),
+            axis="x",
+            lower_limit_rad=-1.65806,  # -95 deg
+            upper_limit_rad=1.65806,  # +95 deg
+        ),
+        RevoluteJoint(
+            name="wrist_roll",
+            parent_to_joint=translation(0.0, -0.0611, 0.0181),
+            axis="y",
+            lower_limit_rad=-2.74385,  # -157.2 deg
+            upper_limit_rad=2.84121,  # +162.8 deg
+        ),
+    ]
+
+    # Fixed transform from wrist_roll frame to end-effector tip
+    # (gripper_frame_joint offset from the URDF).
+    ee_fixed = translation(-0.0079, 0.0, -0.0981)
+
+    return KinematicChain(joints=joints, ee_fixed_transform=ee_fixed)
+
+
+def koch_chain() -> KinematicChain:
+    """Create the kinematic chain for the Koch v1.1 robot (5-DOF, excluding gripper).
+
+    .. warning::
+
+        Koch has **no official URDF**.  The parameters below are rough
+        approximations from MuJoCo menagerie and CAD drawings.  Every numeric
+        constant is marked with ``TODO(physical-params)`` and **must** be
+        validated against the physical robot before production use.
+
+    TODO(physical-params): Validate shoulder_pan offset against real robot.
+    TODO(physical-params): Measure exact upper_arm length (currently ~110 mm est.).
+    TODO(physical-params): Measure exact forearm length (currently ~100 mm est.).
+    TODO(physical-params): Validate wrist offset and EE frame position.
+    TODO(physical-params): Measure and confirm joint axis directions.
+    TODO(physical-params): Calibrate joint limit values against real hardware.
+    """
+    joints = [
+        RevoluteJoint(
+            name="shoulder_pan",
+            # TODO(physical-params): Approximate. Measure base-to-shoulder offset.
+            parent_to_joint=translation(0.0, 0.0, 0.05),
+            axis="y",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-2.61799,  # -150 deg (estimate)
+            upper_limit_rad=2.61799,  # +150 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="shoulder_lift",
+            # TODO(physical-params): Approximate shoulder-to-upper-arm offset.
+            parent_to_joint=translation(0.0, 0.0, -0.04),
+            axis="x",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-1.74533,  # -100 deg (estimate)
+            upper_limit_rad=1.74533,  # +100 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="elbow",
+            # Upper arm length ~110 mm
+            # TODO(physical-params): Measure precisely.
+            parent_to_joint=translation(-0.110, 0.0, 0.0),
+            axis="x",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-1.74533,  # -100 deg (estimate)
+            upper_limit_rad=1.74533,  # +100 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="wrist_flex",
+            # Forearm length ~100 mm
+            # TODO(physical-params): Measure precisely.
+            parent_to_joint=translation(-0.100, 0.0, 0.0),
+            axis="x",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-1.74533,  # -100 deg (estimate)
+            upper_limit_rad=1.74533,  # +100 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="wrist_roll",
+            # TODO(physical-params): Approximate wrist-to-gripper offset.
+            parent_to_joint=translation(0.0, -0.04, 0.0),
+            axis="y",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-3.14159,  # -180 deg (estimate)
+            upper_limit_rad=3.14159,  # +180 deg (estimate)
+        ),
+    ]
+
+    # TODO(physical-params): Measure precise EE offset from wrist_roll.
+    ee_fixed = translation(0.0, 0.0, -0.06)
+
+    return KinematicChain(joints=joints, ee_fixed_transform=ee_fixed)

--- a/src/robopy/kinematics/transforms.py
+++ b/src/robopy/kinematics/transforms.py
@@ -1,0 +1,62 @@
+"""Homogeneous transformation utilities using only numpy."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def rot_x(theta: float) -> NDArray[np.float64]:
+    """4x4 rotation matrix about X-axis. theta in radians."""
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, c, -s, 0.0],
+        [0.0, s, c, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ])
+
+
+def rot_y(theta: float) -> NDArray[np.float64]:
+    """4x4 rotation matrix about Y-axis. theta in radians."""
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([
+        [c, 0.0, s, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [-s, 0.0, c, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ])
+
+
+def rot_z(theta: float) -> NDArray[np.float64]:
+    """4x4 rotation matrix about Z-axis. theta in radians."""
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([
+        [c, -s, 0.0, 0.0],
+        [s, c, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ])
+
+
+def translation(x: float, y: float, z: float) -> NDArray[np.float64]:
+    """4x4 pure translation matrix."""
+    T = np.eye(4)
+    T[0, 3] = x
+    T[1, 3] = y
+    T[2, 3] = z
+    return T
+
+
+def pose_from_matrix(T: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Extract (x, y, z, pitch, roll) from a 4x4 homogeneous matrix.
+
+    Convention (Y-X intrinsic / extrinsic ZYX subset):
+        pitch = atan2(-R[2,0], sqrt(R[0,0]^2 + R[1,0]^2))  -- rotation about Y
+        roll  = atan2(R[2,1], R[2,2])                        -- rotation about X
+
+    Yaw is omitted because the 5-DOF arm cannot independently control it.
+    """
+    x, y_val, z = float(T[0, 3]), float(T[1, 3]), float(T[2, 3])
+    R = T[:3, :3]
+    pitch = float(np.arctan2(-R[2, 0], np.sqrt(R[0, 0] ** 2 + R[1, 0] ** 2)))
+    roll = float(np.arctan2(R[2, 1], R[2, 2]))
+    return np.array([x, y_val, z, pitch, roll])

--- a/src/robopy/robots/koch/koch_robot.py
+++ b/src/robopy/robots/koch/koch_robot.py
@@ -3,7 +3,7 @@ import threading
 import time
 from collections import defaultdict
 from logging import getLogger
-from typing import DefaultDict, Dict, List
+from typing import ClassVar, DefaultDict, Dict, List
 
 import numpy as np
 from numpy.typing import NDArray
@@ -19,6 +19,8 @@ from robopy.config.sensor_config.visual_config.camera_config import (
     RealsenseCameraConfig,
     WebCameraConfig,
 )
+from robopy.kinematics import EEPose, IKConfig, IKResult, IKSolver, koch_chain
+from robopy.kinematics.chain import KinematicChain
 from robopy.robots.common.composed import ComposedRobot
 from robopy.sensors.visual.realsense_camera import RealsenseCamera
 from robopy.sensors.visual.web_camera import WebCamera
@@ -30,6 +32,8 @@ logger = getLogger(__name__)
 
 
 class KochRobot(ComposedRobot[KochPairSys, Sensors, KochObs]):
+    _kinematic_chain: ClassVar[KinematicChain | None] = None
+
     def __init__(self, cfg: KochConfig) -> None:
         super().__init__()
         self.config = self._init_config(cfg)
@@ -37,6 +41,7 @@ class KochRobot(ComposedRobot[KochPairSys, Sensors, KochObs]):
         self._robot_system = KochPairSys(self.config)
         self._sensors = self._init_sensors()
         self._cameras: List[WebCamera | RealsenseCamera] = list(self._sensors.cameras or [])
+        self._ik_solver: IKSolver | None = None
 
     def connect(self) -> None:
         try:
@@ -398,6 +403,178 @@ class KochRobot(ComposedRobot[KochPairSys, Sensors, KochObs]):
                 follower_goals[follower_name] = float(leader_action[i])
 
         self._robot_system.send_follower_action(follower_goals)
+
+    # ------------------------------------------------------------------
+    # Kinematics: FK / IK / EE-space actions
+    #
+    # WARNING: Koch has no official URDF.  The kinematic parameters used
+    # here are rough estimates from MuJoCo menagerie and CAD drawings.
+    # See ``robopy.kinematics.robot_chains.koch_chain`` for details and
+    # TODO(physical-params) markers.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def kinematic_chain(cls) -> KinematicChain:
+        """Get the Koch kinematic chain (lazy-initialised, shared)."""
+        if cls._kinematic_chain is None:
+            cls._kinematic_chain = koch_chain()
+        return cls._kinematic_chain
+
+    @classmethod
+    def forward_kinematics(cls, joint_angles_deg: NDArray[np.float32]) -> EEPose:
+        """Compute FK from joint angles (degrees) to end-effector pose.
+
+        Args:
+            joint_angles_deg: (5,) or (6,) array of joint angles in degrees.
+                If 6 values are given the last element (gripper) is ignored.
+
+        Returns:
+            EEPose with position in metres and orientation in radians.
+        """
+        angles = np.asarray(joint_angles_deg, dtype=np.float64)
+        if len(angles) == 6:
+            angles = angles[:5]
+        if len(angles) != 5:
+            raise ValueError(f"Expected 5 or 6 joint angles, got {len(angles)}")
+
+        angles_rad = np.deg2rad(angles)
+        chain = cls.kinematic_chain()
+        pose = chain.forward_kinematics(angles_rad)
+        return EEPose.from_array(pose)
+
+    def _get_ik_solver(self) -> IKSolver:
+        """Get or create the IK solver instance."""
+        if self._ik_solver is None:
+            self._ik_solver = IKSolver(self.kinematic_chain())
+        return self._ik_solver
+
+    def inverse_kinematics(
+        self,
+        target_pose: EEPose | NDArray[np.float32],
+        current_joint_angles_deg: NDArray[np.float32],
+        ik_config: IKConfig | None = None,
+    ) -> IKResult:
+        """Solve IK for a target end-effector pose.
+
+        Args:
+            target_pose: Desired EE pose (EEPose or (5,) array
+                ``[x, y, z, pitch, roll]``).
+            current_joint_angles_deg: (5,) or (6,) current joint angles in
+                degrees used as the initial guess.
+            ik_config: Optional override for solver parameters.
+
+        Returns:
+            IKResult with ``joint_angles_rad`` in radians.
+        """
+        if isinstance(target_pose, EEPose):
+            target = target_pose.to_array()
+        else:
+            target = np.asarray(target_pose, dtype=np.float64)
+
+        current = np.asarray(current_joint_angles_deg, dtype=np.float64)
+        if len(current) == 6:
+            current = current[:5]
+        current_rad = np.deg2rad(current)
+
+        solver = self._get_ik_solver()
+        if ik_config is not None:
+            solver = IKSolver(self.kinematic_chain(), ik_config)
+
+        return solver.solve(target, current_rad)
+
+    def send_ee_frame_action(
+        self,
+        ee_action: NDArray[np.float32],
+        current_joint_angles_deg: NDArray[np.float32] | None = None,
+        gripper_deg: float = 0.0,
+    ) -> None:
+        """Send a single end-effector pose action to the robot.
+
+        Args:
+            ee_action: (5,) array ``[x, y, z, pitch, roll]`` **or** (6,) array
+                ``[x, y, z, pitch, roll, gripper_deg]``.
+            current_joint_angles_deg: (5,) or (6,) current joint angles in
+                degrees.  If *None* the current follower positions are read.
+            gripper_deg: Gripper angle in degrees (used when *ee_action* is
+                5-dimensional).
+        """
+        if not self.is_connected:
+            raise ConnectionError("KochRobot is not connected. Call connect() first.")
+
+        ee = np.asarray(ee_action, dtype=np.float64)
+        if len(ee) == 6:
+            gripper_deg = float(ee[5])
+            ee = ee[:5]
+
+        if current_joint_angles_deg is None:
+            obs = self.get_arm_observation()
+            current_joint_angles_deg = obs.follower
+
+        result = self.inverse_kinematics(ee, current_joint_angles_deg)
+
+        if not result.success:
+            logger.warning(
+                "IK did not converge (best-effort). pos_err=%.4f m, ori_err=%.4f rad",
+                result.position_error,
+                result.orientation_error,
+            )
+
+        joint_deg = np.rad2deg(result.joint_angles_rad).astype(np.float32)
+        full_action = np.append(joint_deg, np.float32(gripper_deg))
+        self.send_frame_action(full_action)
+
+    def send_ee(
+        self,
+        max_frame: int,
+        fps: int,
+        ee_actions: NDArray[np.float32],
+        teleop_hz: int = 100,
+    ) -> None:
+        """Send a trajectory of end-effector poses to the robot.
+
+        Each row of *ee_actions* is converted to joint angles via IK.  The
+        previous frame's solution is used as the seed for the next frame so
+        that the resulting joint trajectory is smooth.
+
+        Args:
+            max_frame: Number of frames in the trajectory.
+            fps: Playback frame-rate.
+            ee_actions: (max_frame, 5) or (max_frame, 6) end-effector poses.
+                If 6 columns, the last column is the gripper angle in degrees.
+            teleop_hz: Motor command rate.
+        """
+        if not self.is_connected:
+            raise ConnectionError("KochRobot is not connected. Call connect() first.")
+
+        if ee_actions.shape[0] != max_frame:
+            raise ValueError("ee_actions length must match max_frame.")
+
+        obs = self.get_arm_observation()
+        current_joints = obs.follower  # (6,) degrees
+
+        joint_actions = np.zeros((max_frame, 6), dtype=np.float32)
+        for i in range(max_frame):
+            ee = ee_actions[i]
+            if len(ee) >= 6:
+                gripper = float(ee[5])
+                ee_5 = ee[:5]
+            else:
+                gripper = float(current_joints[5]) if len(current_joints) > 5 else 0.0
+                ee_5 = ee
+
+            result = self.inverse_kinematics(ee_5, current_joints)
+            joint_deg = np.rad2deg(result.joint_angles_rad).astype(np.float32)
+            joint_actions[i, :5] = joint_deg
+            joint_actions[i, 5] = gripper
+
+            # Use this solution as seed for the next frame
+            current_joints = joint_actions[i]
+
+        self.send(max_frame, fps, joint_actions, teleop_hz)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
 
     def _init_config(self, cfg: KochConfig) -> KochConfig:
         if cfg.sensors is None:

--- a/tests/test_kinematics/test_chain.py
+++ b/tests/test_kinematics/test_chain.py
@@ -1,0 +1,102 @@
+"""Tests for robopy.kinematics.chain."""
+
+import numpy as np
+import pytest
+
+from robopy.kinematics.chain import KinematicChain, RevoluteJoint
+from robopy.kinematics.transforms import translation
+
+
+def _simple_2dof_chain() -> KinematicChain:
+    """A simple 2-joint planar chain for testing.
+
+    Joint layout (all rotations about Z):
+      base → translate(0.1, 0, 0) → rot_z(q0) → translate(0.2, 0, 0) → rot_z(q1) → EE at (0.15, 0, 0)
+    """
+    joints = [
+        RevoluteJoint(
+            name="j0",
+            parent_to_joint=translation(0.1, 0.0, 0.0),
+            axis="z",
+            lower_limit_rad=-np.pi,
+            upper_limit_rad=np.pi,
+        ),
+        RevoluteJoint(
+            name="j1",
+            parent_to_joint=translation(0.2, 0.0, 0.0),
+            axis="z",
+            lower_limit_rad=-np.pi,
+            upper_limit_rad=np.pi,
+        ),
+    ]
+    ee = translation(0.15, 0.0, 0.0)
+    return KinematicChain(joints=joints, ee_fixed_transform=ee)
+
+
+class TestKinematicChain:
+    def test_properties(self):
+        chain = _simple_2dof_chain()
+        assert chain.n_joints == 2
+        assert chain.joint_names == ["j0", "j1"]
+
+    def test_fk_zeros(self):
+        """All joints at zero → EE at sum of offsets along X."""
+        chain = _simple_2dof_chain()
+        T = chain.forward_kinematics_matrix(np.array([0.0, 0.0]))
+        # x = 0.1 + 0.2 + 0.15 = 0.45, y = 0, z = 0
+        np.testing.assert_allclose(T[:3, 3], [0.45, 0.0, 0.0], atol=1e-14)
+
+    def test_fk_pose_zeros(self):
+        chain = _simple_2dof_chain()
+        pose = chain.forward_kinematics(np.array([0.0, 0.0]))
+        assert pose.shape == (5,)
+        np.testing.assert_allclose(pose[:3], [0.45, 0.0, 0.0], atol=1e-14)
+
+    def test_fk_90_first_joint(self):
+        """Rotate first joint 90° about Z → second link points in +Y."""
+        chain = _simple_2dof_chain()
+        T = chain.forward_kinematics_matrix(np.array([np.pi / 2, 0.0]))
+        # After q0=90deg: the 0.2 and 0.15 offsets now go in Y direction
+        # x = 0.1, y = 0.2 + 0.15 = 0.35
+        np.testing.assert_allclose(T[0, 3], 0.1, atol=1e-14)
+        np.testing.assert_allclose(T[1, 3], 0.35, atol=1e-14)
+        np.testing.assert_allclose(T[2, 3], 0.0, atol=1e-14)
+
+    def test_wrong_number_of_angles(self):
+        chain = _simple_2dof_chain()
+        with pytest.raises(ValueError, match="Expected 2"):
+            chain.forward_kinematics(np.array([0.0]))
+
+    def test_jacobian_shape(self):
+        chain = _simple_2dof_chain()
+        J = chain.jacobian(np.array([0.0, 0.0]))
+        assert J.shape == (5, 2)
+
+    def test_jacobian_finite_difference_consistency(self):
+        """Jacobian should be consistent with finite-difference check."""
+        chain = _simple_2dof_chain()
+        q = np.array([0.3, -0.5])
+        J = chain.jacobian(q, delta=1e-6)
+
+        # Verify with a larger delta for comparison
+        J2 = chain.jacobian(q, delta=1e-4)
+        # Should agree to within O(delta^2)
+        np.testing.assert_allclose(J, J2, atol=1e-5)
+
+    def test_clamp_to_limits(self):
+        chain = _simple_2dof_chain()
+        q = np.array([5.0, -5.0])
+        clamped = chain.clamp_to_limits(q)
+        np.testing.assert_allclose(clamped, [np.pi, -np.pi], atol=1e-14)
+
+
+class TestRevoluteJoint:
+    def test_invalid_axis(self):
+        with pytest.raises(ValueError, match="axis must be"):
+            RevoluteJoint(
+                name="bad",
+                parent_to_joint=np.eye(4),
+                axis="w",
+                lower_limit_rad=0,
+                upper_limit_rad=1,
+            )

--- a/tests/test_kinematics/test_ik_solver.py
+++ b/tests/test_kinematics/test_ik_solver.py
@@ -1,0 +1,166 @@
+"""Tests for robopy.kinematics.ik_solver."""
+
+import numpy as np
+import pytest
+
+from robopy.kinematics.chain import KinematicChain, RevoluteJoint
+from robopy.kinematics.ik_solver import IKConfig, IKResult, IKSolver
+from robopy.kinematics.robot_chains import koch_chain, so101_chain
+from robopy.kinematics.transforms import translation
+
+
+def _simple_3dof_chain() -> KinematicChain:
+    """3-DOF chain with X/Y/Z rotation — enough to reach 3D positions."""
+    joints = [
+        RevoluteJoint(
+            name="j0",
+            parent_to_joint=translation(0.0, 0.0, 0.05),
+            axis="y",
+            lower_limit_rad=-np.pi,
+            upper_limit_rad=np.pi,
+        ),
+        RevoluteJoint(
+            name="j1",
+            parent_to_joint=translation(0.0, 0.0, 0.0),
+            axis="x",
+            lower_limit_rad=-np.pi / 2,
+            upper_limit_rad=np.pi / 2,
+        ),
+        RevoluteJoint(
+            name="j2",
+            parent_to_joint=translation(-0.15, 0.0, 0.0),
+            axis="x",
+            lower_limit_rad=-np.pi / 2,
+            upper_limit_rad=np.pi / 2,
+        ),
+    ]
+    ee = translation(-0.1, 0.0, 0.0)
+    return KinematicChain(joints=joints, ee_fixed_transform=ee)
+
+
+class TestIKSolverSimple:
+    """IK solver tests with a simple 3-DOF chain."""
+
+    def test_solve_at_home(self):
+        """IK at the home (zero-angle) pose should converge trivially."""
+        chain = _simple_3dof_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(3))
+        result = solver.solve(home_pose, np.zeros(3))
+        assert result.success
+        assert result.position_error < 1e-4
+
+    def test_roundtrip(self):
+        """FK → IK → FK should recover the original pose."""
+        chain = _simple_3dof_chain()
+        solver = IKSolver(chain, IKConfig(max_iterations=200))
+
+        rng = np.random.default_rng(42)
+        for _ in range(5):
+            q_rand = rng.uniform(
+                chain.lower_limits_rad * 0.5,
+                chain.upper_limits_rad * 0.5,
+            )
+            target_pose = chain.forward_kinematics(q_rand)
+            # Use a slightly perturbed starting point
+            q_init = q_rand + rng.normal(0, 0.1, size=3)
+            q_init = chain.clamp_to_limits(q_init)
+
+            result = solver.solve(target_pose, q_init)
+            recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
+
+            np.testing.assert_allclose(
+                recovered_pose[:3], target_pose[:3], atol=1e-3,
+                err_msg="Position mismatch in FK→IK→FK roundtrip",
+            )
+
+    def test_result_fields(self):
+        chain = _simple_3dof_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(3))
+        result = solver.solve(home_pose, np.zeros(3))
+        assert isinstance(result, IKResult)
+        assert isinstance(result.success, bool)
+        assert isinstance(result.iterations, int)
+        assert result.iterations >= 1
+
+
+class TestIKSolverSO101:
+    """IK tests using the real SO-101 chain definition."""
+
+    def test_home_pose_roundtrip(self):
+        chain = so101_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(5))
+        result = solver.solve(home_pose, np.zeros(5))
+        assert result.success
+        assert result.position_error < 1e-3
+
+    def test_random_roundtrip(self):
+        chain = so101_chain()
+        solver = IKSolver(chain, IKConfig(max_iterations=200))
+        rng = np.random.default_rng(123)
+
+        for _ in range(5):
+            q_rand = rng.uniform(
+                chain.lower_limits_rad * 0.3,
+                chain.upper_limits_rad * 0.3,
+            )
+            target_pose = chain.forward_kinematics(q_rand)
+            q_init = q_rand + rng.normal(0, 0.05, size=5)
+            q_init = chain.clamp_to_limits(q_init)
+
+            result = solver.solve(target_pose, q_init)
+            recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
+
+            np.testing.assert_allclose(
+                recovered_pose[:3], target_pose[:3], atol=5e-3,
+                err_msg="SO-101 FK→IK→FK position mismatch",
+            )
+
+    def test_joint_limits_respected(self):
+        chain = so101_chain()
+        config = IKConfig(joint_limit_margin_rad=0.02)
+        solver = IKSolver(chain, config)
+
+        home_pose = chain.forward_kinematics(np.zeros(5))
+        result = solver.solve(home_pose, np.zeros(5))
+
+        lower = chain.lower_limits_rad + config.joint_limit_margin_rad
+        upper = chain.upper_limits_rad - config.joint_limit_margin_rad
+        assert np.all(result.joint_angles_rad >= lower - 1e-10)
+        assert np.all(result.joint_angles_rad <= upper + 1e-10)
+
+
+class TestIKSolverKoch:
+    """IK tests using the Koch chain definition (estimated parameters)."""
+
+    def test_home_pose_roundtrip(self):
+        chain = koch_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(5))
+        result = solver.solve(home_pose, np.zeros(5))
+        assert result.success
+        assert result.position_error < 1e-3
+
+    def test_random_roundtrip(self):
+        chain = koch_chain()
+        solver = IKSolver(chain, IKConfig(max_iterations=200))
+        rng = np.random.default_rng(456)
+
+        for _ in range(5):
+            q_rand = rng.uniform(
+                chain.lower_limits_rad * 0.3,
+                chain.upper_limits_rad * 0.3,
+            )
+            target_pose = chain.forward_kinematics(q_rand)
+            q_init = q_rand + rng.normal(0, 0.05, size=5)
+            q_init = chain.clamp_to_limits(q_init)
+
+            result = solver.solve(target_pose, q_init)
+            recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
+
+            np.testing.assert_allclose(
+                recovered_pose[:3], target_pose[:3], atol=5e-3,
+                err_msg="Koch FK→IK→FK position mismatch",
+            )

--- a/tests/test_kinematics/test_robot_chains.py
+++ b/tests/test_kinematics/test_robot_chains.py
@@ -1,0 +1,71 @@
+"""Smoke tests for robot-specific kinematic chain factories."""
+
+import numpy as np
+
+from robopy.kinematics.ee_pose import EEPose
+from robopy.kinematics.robot_chains import koch_chain, so101_chain
+
+
+class TestSO101Chain:
+    def test_creation(self):
+        chain = so101_chain()
+        assert chain.n_joints == 5
+        assert chain.joint_names == [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+        ]
+
+    def test_fk_home_position(self):
+        """At zero angles the EE should be at the sum of all offsets."""
+        chain = so101_chain()
+        T = chain.forward_kinematics_matrix(np.zeros(5))
+        # The EE should be at a reasonable position (non-zero, within arm reach)
+        pos = T[:3, 3]
+        reach = np.linalg.norm(pos)
+        assert 0.01 < reach < 0.6, f"Unexpected reach {reach} m at home"
+
+    def test_fk_returns_ee_pose(self):
+        chain = so101_chain()
+        pose = chain.forward_kinematics(np.zeros(5))
+        assert pose.shape == (5,)
+        ee = EEPose.from_array(pose)
+        assert isinstance(ee, EEPose)
+
+    def test_joint_limits(self):
+        chain = so101_chain()
+        lower = chain.lower_limits_rad
+        upper = chain.upper_limits_rad
+        assert len(lower) == 5
+        assert len(upper) == 5
+        assert np.all(lower < upper)
+
+
+class TestKochChain:
+    def test_creation(self):
+        chain = koch_chain()
+        assert chain.n_joints == 5
+        assert chain.joint_names == [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow",
+            "wrist_flex",
+            "wrist_roll",
+        ]
+
+    def test_fk_home_position(self):
+        chain = koch_chain()
+        T = chain.forward_kinematics_matrix(np.zeros(5))
+        pos = T[:3, 3]
+        reach = np.linalg.norm(pos)
+        assert 0.01 < reach < 0.5, f"Unexpected reach {reach} m at home"
+
+    def test_joint_limits(self):
+        chain = koch_chain()
+        lower = chain.lower_limits_rad
+        upper = chain.upper_limits_rad
+        assert len(lower) == 5
+        assert len(upper) == 5
+        assert np.all(lower < upper)

--- a/tests/test_kinematics/test_transforms.py
+++ b/tests/test_kinematics/test_transforms.py
@@ -1,0 +1,87 @@
+"""Tests for robopy.kinematics.transforms."""
+
+import numpy as np
+import pytest
+
+from robopy.kinematics.transforms import (
+    pose_from_matrix,
+    rot_x,
+    rot_y,
+    rot_z,
+    translation,
+)
+
+
+class TestRotationMatrices:
+    """Basic properties of rotation matrices."""
+
+    @pytest.mark.parametrize("rot_fn", [rot_x, rot_y, rot_z])
+    def test_identity_at_zero(self, rot_fn):
+        np.testing.assert_allclose(rot_fn(0.0), np.eye(4), atol=1e-15)
+
+    @pytest.mark.parametrize("rot_fn", [rot_x, rot_y, rot_z])
+    def test_orthogonality(self, rot_fn):
+        R = rot_fn(0.7)[:3, :3]
+        np.testing.assert_allclose(R @ R.T, np.eye(3), atol=1e-14)
+
+    @pytest.mark.parametrize("rot_fn", [rot_x, rot_y, rot_z])
+    def test_determinant_is_one(self, rot_fn):
+        R = rot_fn(1.2)[:3, :3]
+        assert abs(np.linalg.det(R) - 1.0) < 1e-14
+
+    def test_rot_x_90(self):
+        T = rot_x(np.pi / 2)
+        # Y-axis → Z-axis, Z-axis → -Y-axis
+        np.testing.assert_allclose(T[:3, :3] @ [0, 1, 0], [0, 0, 1], atol=1e-14)
+        np.testing.assert_allclose(T[:3, :3] @ [0, 0, 1], [0, -1, 0], atol=1e-14)
+
+    def test_rot_y_90(self):
+        T = rot_y(np.pi / 2)
+        # Z-axis → X-axis, X-axis → -Z-axis... actually:
+        # rot_y: X→Z component positive, Z→-X
+        np.testing.assert_allclose(T[:3, :3] @ [1, 0, 0], [0, 0, -1], atol=1e-14)
+        np.testing.assert_allclose(T[:3, :3] @ [0, 0, 1], [1, 0, 0], atol=1e-14)
+
+    def test_rot_z_90(self):
+        T = rot_z(np.pi / 2)
+        np.testing.assert_allclose(T[:3, :3] @ [1, 0, 0], [0, 1, 0], atol=1e-14)
+        np.testing.assert_allclose(T[:3, :3] @ [0, 1, 0], [-1, 0, 0], atol=1e-14)
+
+
+class TestTranslation:
+    def test_basic(self):
+        T = translation(1.0, 2.0, 3.0)
+        assert T.shape == (4, 4)
+        np.testing.assert_allclose(T[:3, 3], [1.0, 2.0, 3.0])
+        np.testing.assert_allclose(T[:3, :3], np.eye(3))
+
+    def test_zero(self):
+        np.testing.assert_allclose(translation(0, 0, 0), np.eye(4))
+
+
+class TestPoseFromMatrix:
+    def test_identity(self):
+        pose = pose_from_matrix(np.eye(4))
+        np.testing.assert_allclose(pose, [0, 0, 0, 0, 0], atol=1e-14)
+
+    def test_pure_translation(self):
+        T = translation(0.1, 0.2, 0.3)
+        pose = pose_from_matrix(T)
+        np.testing.assert_allclose(pose[:3], [0.1, 0.2, 0.3])
+        np.testing.assert_allclose(pose[3:], [0, 0], atol=1e-14)
+
+    def test_pitch_only(self):
+        # Pitch = rotation about Y-axis
+        angle = 0.5
+        T = rot_y(angle)
+        pose = pose_from_matrix(T)
+        np.testing.assert_allclose(pose[3], angle, atol=1e-14)  # pitch
+        np.testing.assert_allclose(pose[4], 0.0, atol=1e-14)  # roll
+
+    def test_roll_only(self):
+        # Roll = rotation about X-axis
+        angle = 0.3
+        T = rot_x(angle)
+        pose = pose_from_matrix(T)
+        np.testing.assert_allclose(pose[3], 0.0, atol=1e-14)  # pitch
+        np.testing.assert_allclose(pose[4], angle, atol=1e-14)  # roll


### PR DESCRIPTION
Implement full SO-101 arm support following robopy's existing Koch/Rakuda
patterns, referencing huggingface/lerobot for hardware specifications.

New motor layer:
- FeetechControlItem and STSControlTable for STS3215 control table
- FeetechBus/FeetechMotor with sync_read/sync_write, calibration,
  and sign-magnitude encoding required by the Feetech protocol

New robot implementation:
- So101Leader/So101Follower (6-DOF: shoulder_pan, shoulder_lift,
  elbow_flex, wrist_flex, wrist_roll, gripper)
- So101PairSys for leader-follower teleoperation with calibration
- So101Robot (ComposedRobot) with record, record_parallel, send
- Calibration procedure adapted for Feetech motors
- So101SaveWorker with observation types

Updated:
- Arm base class to accept FeetechBus via MotorBus union type
- pyproject.toml with feetech-servo-sdk dependency
- Package exports for So101Config, So101Robot, etc.

https://claude.ai/code/session_01RGTev5J7cTEa8kAzoCsAAg