### PR TITLE
Refactor motor calibration to match lerobot format with range-based normalization

### DIFF
--- a/src/robopy/robots/so101/calibration.py
+++ b/src/robopy/robots/so101/calibration.py
@@ -3,44 +3,28 @@
 """
 Calibration procedure for SO-101 arms using Feetech STS3215 motors.
 
-The STS3215 uses a 12-bit encoder (0-4095 steps per rotation).
-Calibration determines a homing offset and drive mode (inversion) for each
-motor so that the zero-degree position matches a known physical pose.
+Matches the latest lerobot calibration approach:
+1. Move arm to the middle of its range → compute homing offsets (half-turn centering)
+2. Move all joints through their full range → record min/max positions
+3. wrist_roll is treated as a full-rotation joint (range 0–4095)
+
+The calibration data is stored as a dict of MotorCalibration per motor.
 """
 
-from typing import Dict, List, Tuple
+import logging
+from typing import Dict
 
-import numpy as np
-from numpy.typing import NDArray
-
-from robopy.motor.feetech_bus import FeetechBus
+from robopy.motor.feetech_bus import FeetechBus, MotorCalibration
 from robopy.motor.feetech_control_table import STSControlTable
 from robopy.robots.common.arm import Arm
 
-ZERO_POSITION_DEGREE = 0
-ROTATED_POSITION_DEGREE = 90
+logger = logging.getLogger(__name__)
+
+FULL_TURN_MOTOR = "wrist_roll"
 
 
-def convert_degrees_to_steps(degrees: float, resolutions: List[int]) -> NDArray[np.int_]:
-    """Converts degrees to motor steps based on motor resolutions."""
-    steps = np.array(degrees) / 180.0 * np.array(resolutions) / 2.0
-    return steps.astype(int)
-
-
-def assert_drive_mode(drive_mode: NDArray[np.int_]) -> None:
-    if not np.all(np.isin(drive_mode, [0, 1])):
-        raise ValueError(f"`drive_mode` contains values other than 0 or 1: ({drive_mode})")
-
-
-def apply_drive_mode(position: NDArray[np.int_], drive_mode: NDArray[np.int_]) -> NDArray[np.int_]:
-    assert_drive_mode(drive_mode)
-    signed_drive_mode = -(drive_mode * 2 - 1)
-    position *= signed_drive_mode
-    return position
-
-
-def reset_torque_and_set_mode(arm: Arm) -> None:
-    """Disables torque and sets the correct operating modes for calibration."""
+def _disable_torque_and_set_position_mode(arm: Arm) -> FeetechBus:
+    """Disables torque and sets position mode for all motors. Returns the bus."""
     bus = arm.motors
     if bus is None:
         raise RuntimeError(f"Motors for {arm} are not initialized.")
@@ -49,80 +33,67 @@ def reset_torque_and_set_mode(arm: Arm) -> None:
 
     all_motor_names = arm.motor_names
 
-    # Disable torque for all motors
-    disable_torque_values: Dict[str, int | float] = {name: 0 for name in all_motor_names}
-    bus.sync_write(STSControlTable.TORQUE_ENABLE, disable_torque_values)
+    # Disable torque
+    bus.sync_write(STSControlTable.TORQUE_ENABLE, {name: 0 for name in all_motor_names})
 
     # Set position mode (mode 0) for all motors
-    position_mode_values: Dict[str, int | float] = {name: 0 for name in all_motor_names}
-    bus.sync_write(STSControlTable.OPERATING_MODE, position_mode_values)
+    bus.sync_write(STSControlTable.OPERATING_MODE, {name: 0 for name in all_motor_names})
+
+    return bus
 
 
-def run_arm_calibration(arm: Arm, arm_type: str) -> Dict[str, Tuple[int, bool]]:
+def run_arm_calibration(arm: Arm, arm_type: str) -> Dict[str, MotorCalibration]:
     """
     Runs the interactive calibration procedure for a single SO-101 arm.
-    This function determines the homing offset and drive mode for each motor.
+
+    Procedure (matching lerobot):
+    1. Move arm to the middle of its range of motion → set homing offsets
+    2. Move all joints (except wrist_roll) through their full range → record min/max
+    3. wrist_roll gets hardcoded range [0, 4095]
     """
-    reset_torque_and_set_mode(arm)
-
-    if arm.motors is None:
-        raise RuntimeError(f"Motors for {arm_type} arm are not initialized.")
-
+    bus = _disable_torque_and_set_position_mode(arm)
     motor_names = arm.motor_names
-    resolutions = [arm.motors.motors[name].resolution for name in motor_names]
 
     print(f"\n>> Running calibration of the SO-101 {arm_type} arm...")
 
-    print("\n[Step 1/2] Move the arm to the ZERO position.")
-    print("  All joints should be at their neutral/zero angle.")
+    # --- Step 1: Set homing offsets (half-turn centering) ---
+    print("\n[Step 1/2] Move the arm to the MIDDLE of its range of motion.")
+    print("  Each joint should be approximately at the center of how far it can move.")
     input("Press Enter when ready...")
 
-    # --- Homing Offset Calculation (First Pass) ---
-    zero_pos_steps = convert_degrees_to_steps(ZERO_POSITION_DEGREE, resolutions)
+    homing_offsets = bus.set_half_turn_homings()
+    logger.info(f"Homing offsets: {homing_offsets}")
 
-    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
-    current_pos = np.array([pos_dict[name] for name in motor_names])
+    # --- Step 2: Record ranges of motion ---
+    print("\n[Step 2/2] Move all joints (except wrist_roll) through their full range of motion.")
+    print("  Slowly sweep each joint from one limit to the other.")
 
-    # Round to nearest quarter turn to reduce manual positioning errors
-    quarter_turn_steps = convert_degrees_to_steps(90, resolutions)
-    rounded_pos = np.round(current_pos.astype(float) / quarter_turn_steps) * quarter_turn_steps
+    unknown_range_motors = [name for name in motor_names if name != FULL_TURN_MOTOR]
+    range_mins, range_maxes = bus.record_ranges_of_motion(unknown_range_motors)
 
-    homing_offset = zero_pos_steps - rounded_pos.astype(int)
-
-    # --- Drive Mode Calculation ---
-    print("\n[Step 2/2] Move the arm to the ROTATED position.")
-    print("  Rotate each joint approximately +90 degrees from the zero position.")
-    input("Press Enter when ready...")
-
-    rotated_pos_steps = convert_degrees_to_steps(ROTATED_POSITION_DEGREE, resolutions)
-
-    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
-    current_pos = np.array([pos_dict[name] for name in motor_names])
-
-    # Apply preliminary offset and round
-    pos_with_offset = current_pos + homing_offset
-    rounded_pos = np.round(pos_with_offset.astype(float) / quarter_turn_steps) * quarter_turn_steps
-
-    # If the rounded position doesn't match the target, the drive mode is inverted
-    drive_mode = (rounded_pos != rotated_pos_steps).astype(np.int32)
-
-    # --- Homing Offset Refinement (Second Pass) ---
-    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
-    current_pos = np.array([pos_dict[name] for name in motor_names])
-
-    pos_with_drive_mode = apply_drive_mode(current_pos, drive_mode)
-    rounded_pos = (
-        np.round(pos_with_drive_mode.astype(float) / quarter_turn_steps) * quarter_turn_steps
-    )
-
-    homing_offset = rotated_pos_steps - rounded_pos.astype(int)
+    # wrist_roll is a full-rotation joint
+    if FULL_TURN_MOTOR in motor_names:
+        resolution = bus.motors[FULL_TURN_MOTOR].resolution
+        range_mins[FULL_TURN_MOTOR] = 0
+        range_maxes[FULL_TURN_MOTOR] = resolution - 1  # 4095
 
     print("\nCalibration for this arm is complete. Please move it to a safe rest position.")
     input("Press Enter to continue...")
 
-    # --- Format and Return Calibration Data ---
-    calibration_data = {
-        name: (int(homing_offset[i]), bool(drive_mode[i])) for i, name in enumerate(motor_names)
-    }
+    # --- Build calibration data ---
+    calibration: Dict[str, MotorCalibration] = {}
+    for name in motor_names:
+        motor = bus.motors[name]
+        calibration[name] = MotorCalibration(
+            id=motor.id,
+            drive_mode=0,
+            homing_offset=homing_offsets[name],
+            range_min=range_mins[name],
+            range_max=range_maxes[name],
+        )
 
-    return calibration_data
+    # Write calibration to motor EEPROM
+    bus.set_calibration(calibration)
+    bus.write_calibration_to_motors()
+
+    return calibration

--- a/src/robopy/robots/so101/so101_follower.py
+++ b/src/robopy/robots/so101/so101_follower.py
@@ -1,7 +1,7 @@
 import logging
 
 from robopy.config.robot_config.so101_config import So101Config
-from robopy.motor.feetech_bus import FeetechBus, FeetechMotor
+from robopy.motor.feetech_bus import FeetechBus, FeetechMotor, NormMode
 from robopy.motor.feetech_control_table import STSControlTable
 from robopy.robots.common.arm import Arm
 
@@ -27,7 +27,7 @@ class So101Follower(Arm):
                 "elbow_flex": FeetechMotor(3, "elbow_flex", "sts3215"),
                 "wrist_flex": FeetechMotor(4, "wrist_flex", "sts3215"),
                 "wrist_roll": FeetechMotor(5, "wrist_roll", "sts3215"),
-                "gripper": FeetechMotor(6, "gripper", "sts3215"),
+                "gripper": FeetechMotor(6, "gripper", "sts3215", NormMode.RANGE_0_100),
             },
         )
         self._is_connected = False

--- a/src/robopy/robots/so101/so101_leader.py
+++ b/src/robopy/robots/so101/so101_leader.py
@@ -1,7 +1,7 @@
 import logging
 
 from robopy.config.robot_config.so101_config import So101Config
-from robopy.motor.feetech_bus import FeetechBus, FeetechMotor
+from robopy.motor.feetech_bus import FeetechBus, FeetechMotor, NormMode
 from robopy.motor.feetech_control_table import STSControlTable
 from robopy.robots.common.arm import Arm
 
@@ -31,7 +31,7 @@ class So101Leader(Arm):
                     "elbow_flex": FeetechMotor(3, "elbow_flex", "sts3215"),
                     "wrist_flex": FeetechMotor(4, "wrist_flex", "sts3215"),
                     "wrist_roll": FeetechMotor(5, "wrist_roll", "sts3215"),
-                    "gripper": FeetechMotor(6, "gripper", "sts3215"),
+                    "gripper": FeetechMotor(6, "gripper", "sts3215", NormMode.RANGE_0_100),
                 },
             )
         self._is_connected = False


### PR DESCRIPTION
## Summary
This PR refactors the motor calibration system to align with lerobot's calibration approach. The key changes include:
- Replacing the simple `(homing_offset, inverted)` tuple format with a structured `MotorCalibration` dataclass
- Implementing range-based position normalization (min/max limits) instead of simple offset/inversion
- Supporting two normalization modes: DEGREES and RANGE_0_100
- Simplifying the calibration procedure to use half-turn centering and interactive range recording

## Key Changes

### Motor Calibration Data Structure
- Added `MotorCalibration` dataclass with fields: `id`, `drive_mode`, `homing_offset`, `range_min`, `range_max`
- Includes `to_dict()` and `from_dict()` methods for serialization
- Added `NormMode` enum to support DEGREES and RANGE_0_100 normalization modes
- Updated `FeetechMotor` to accept `norm_mode` parameter

### Calibration Methods
- Added `write_calibration_to_motors()` to persist calibration values to motor EEPROM
- Added `reset_calibration_on_motors()` to reset motors to defaults
- Added `set_half_turn_homings()` to automatically compute homing offsets by centering each motor
- Added `record_ranges_of_motion()` for interactive min/max position recording with real-time display

### Position Normalization
- Refactored `_apply_calibration()` to support range-based normalization:
  - DEGREES mode: converts raw steps to degrees using range midpoint and resolution
  - RANGE_0_100 mode: linearly maps [range_min, range_max] to [0, 100], with optional drive_mode inversion
- Updated `_revert_calibration()` to properly invert the normalization transformations

### Calibration Procedure (SO-101)
- Simplified two-step procedure:
  1. Move arm to middle of range → automatically compute homing offsets
  2. Move joints through full range → record min/max positions
- Special handling for wrist_roll as a full-rotation joint (range 0–4095)
- Removed complex quarter-turn rounding and multi-pass offset refinement

### Serialization
- Changed from pickle to JSON format for calibration persistence
- Updated `SO101PairSys` to use `_save_calibration()` and `_load_calibration()` methods
- Calibration is now written to motor EEPROM after loading

### Code Cleanup
- Removed unused imports and helper functions from calibration module
- Simplified type hints and removed unnecessary intermediate variables

https://claude.ai/code/session_014FzgVwjFEbqVcPD1Li3D8K