### PR TITLE
Update docs to reflect new SO-101 calibration procedure

### DIFF
--- a/docs/api/spacemouse.md
+++ b/docs/api/spacemouse.md
@@ -94,7 +94,7 @@ from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
 
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 
 robot = So101Robot(cfg=config)

--- a/docs/robots/so101.md
+++ b/docs/robots/so101.md
@@ -34,14 +34,14 @@ from robopy.config.robot_config.so101_config import So101Config
 # 基本設定（Followerのみ、Leaderなし）
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 
 # Leader付き設定（テレオペレーション用）
 config = So101Config(
     leader_port="/dev/ttyACM0",
     follower_port="/dev/ttyACM1",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 ```
 
@@ -53,7 +53,7 @@ from robopy.config.sensor_config.visual_config.camera_config import WebCameraCon
 
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
     sensors=So101SensorConfig(
         cameras={
             "top": WebCameraConfig(fps=30, width=640, height=480),
@@ -61,6 +61,68 @@ config = So101Config(
     ),
 )
 ```
+
+## :material-tune: キャリブレーション
+
+`robot.connect()` 時にキャリブレーションファイルが存在しない場合、対話的なキャリブレーションが自動実行されます。キャリブレーション方式は [lerobot](https://github.com/huggingface/lerobot) の最新版と同一です。
+
+### キャリブレーション手順
+
+キャリブレーションは各アーム（Leader / Follower）ごとに2ステップで行います。
+
+**ステップ 1: 可動域の中央位置を設定**
+
+各関節を可動域のおよそ中央に移動し、Enter を押します。各モーターのホーミングオフセット（`homing_offset = 現在位置 - 2047`）が計算され、モーターの EEPROM に書き込まれます。
+
+**ステップ 2: 可動域の記録**
+
+`wrist_roll` 以外の各関節を端から端までゆっくり動かし、Enter を押します。各関節の最小値（`range_min`）・最大値（`range_max`）がリアルタイムで記録されます。`wrist_roll` は全回転関節として `[0, 4095]` が自動設定されます。
+
+### キャリブレーションファイル
+
+キャリブレーションデータは JSON 形式で保存されます。
+
+```json
+{
+    "leader": {
+        "shoulder_pan": {
+            "id": 1,
+            "drive_mode": 0,
+            "homing_offset": -150,
+            "range_min": 1024,
+            "range_max": 3072
+        },
+        "gripper": {
+            "id": 6,
+            "drive_mode": 0,
+            "homing_offset": -80,
+            "range_min": 1500,
+            "range_max": 2600
+        }
+    },
+    "follower": { ... }
+}
+```
+
+| フィールド | 説明 |
+|-----------|------|
+| `id` | モーター ID（1〜6） |
+| `drive_mode` | 駆動方向（0 = 通常） |
+| `homing_offset` | ホーミングオフセット（中央位置の補正値） |
+| `range_min` | 可動域の最小エンコーダ値 |
+| `range_max` | 可動域の最大エンコーダ値 |
+
+### 位置の正規化
+
+キャリブレーションデータに基づき、生のエンコーダ値がユーザー向けの値に変換されます。
+
+- **DEGREES モード**（shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll）:
+    - `(raw - mid) * 360 / 4095`（`mid = (range_min + range_max) / 2`）
+- **RANGE_0_100 モード**（gripper）:
+    - `[range_min, range_max]` → `[0, 100]` への線形マッピング
+
+!!! tip "再キャリブレーション"
+    キャリブレーションをやり直すには、`calibration_path` で指定した JSON ファイルを削除してから `robot.connect()` を呼び出してください。
 
 ### ロボットの操作
 
@@ -70,7 +132,7 @@ from robopy.robots.so101.so101_robot import So101Robot
 robot = So101Robot(config)
 
 try:
-    # 接続（初回はキャリブレーションが実行されます）
+    # 接続（初回はキャリブレーションが自動実行されます）
     robot.connect()
 
     # テレオペレーション（10秒間）
@@ -311,7 +373,7 @@ from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
 # Followerのみの設定（Leaderアーム不要）
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 
 robot = So101Robot(cfg=config)
@@ -384,7 +446,7 @@ from robopy.config.robot_config.so101_config import So101Config, So101SensorConf
 # カメラ付き設定
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
     sensors=So101SensorConfig(
         cameras={
             "top": WebCameraConfig(fps=30, width=640, height=480),


### PR DESCRIPTION
- Change all calibration_path examples from .pkl to .json
- Add dedicated calibration section to so101.md explaining:
  - Two-step procedure (half-turn homing + range recording)
  - JSON calibration file format with MotorCalibration fields
  - DEGREES and RANGE_0_100 normalization modes
  - Re-calibration instructions

https://claude.ai/code/session_014FzgVwjFEbqVcPD1Li3D8K