### PR TITLE
Fix SO-101 forward kinematics to match URDF joint frame orientations

### DIFF
--- a/docs/robots/so101.md
+++ b/docs/robots/so101.md
@@ -233,28 +233,33 @@ T = chain.forward_kinematics_matrix(q)
 
 ### SO-101 のキネマティックパラメータ
 
-SO-101の物理パラメータは[SO-ARM100のURDF](https://github.com/TheRobotStudio/SO-ARM100)から取得しています。
+SO-101の物理パラメータは[SO-ARM100のURDF](https://github.com/TheRobotStudio/SO-ARM100)（`so101_new_calib.urdf`）から取得しています。
+
+URDFではすべての関節が**ローカルZ軸まわりの回転**（`axis xyz="0 0 1"`）として定義されています。各関節のオリジンに含まれるRPY回転がフレームの向きを決定し、ローカルZ軸が正しい物理方向を向くようになっています。
 
 ```mermaid
 graph LR
-    A[Base] -->|"(0.039, 0, 0.062) m"| B[Shoulder Pan<br/>Y軸回転]
-    B -->|"(-0.030, -0.018, -0.054) m"| C[Shoulder Lift<br/>X軸回転]
-    C -->|"(-0.113, -0.028, 0) m"| D[Elbow Flex<br/>X軸回転]
-    D -->|"(-0.135, 0.005, 0) m"| E[Wrist Flex<br/>X軸回転]
-    E -->|"(0, -0.061, 0.018) m"| F[Wrist Roll<br/>Y軸回転]
-    F -->|"(-0.008, 0, -0.098) m"| G[EE Frame]
+    A[Base] -->|"xyz=(0.039, 0, 0.062)<br/>rpy=(π, 0, -π)"| B[Shoulder Pan<br/>Z軸回転]
+    B -->|"xyz=(-0.030, -0.018, -0.054)<br/>rpy=(-π/2, -π/2, 0)"| C[Shoulder Lift<br/>Z軸回転]
+    C -->|"xyz=(-0.113, -0.028, 0)<br/>rpy=(0, 0, π/2)"| D[Elbow Flex<br/>Z軸回転]
+    D -->|"xyz=(-0.135, 0.005, 0)<br/>rpy=(0, 0, -π/2)"| E[Wrist Flex<br/>Z軸回転]
+    E -->|"xyz=(0, -0.061, 0.018)<br/>rpy=(π/2, 0.049, π)"| F[Wrist Roll<br/>Z軸回転]
+    F -->|"xyz=(-0.008, 0, -0.098)<br/>rpy=(0, π, 0)"| G[EE Frame]
 ```
 
-| 関節 | オフセット (m) | 回転軸 | 可動範囲 |
-|------|---------------|--------|---------|
-| shoulder_pan | (0.039, 0, 0.062) | Y | -110° ~ +110° |
-| shoulder_lift | (-0.030, -0.018, -0.054) | X | -100° ~ +100° |
-| elbow_flex | (-0.113, -0.028, 0) | X | -96.8° ~ +96.8° |
-| wrist_flex | (-0.135, 0.005, 0) | X | -95° ~ +95° |
-| wrist_roll | (0, -0.061, 0.018) | Y | -157.2° ~ +162.8° |
+| 関節 | オフセット xyz (m) | オリジン RPY (rad) | 回転軸 | 可動範囲 |
+|------|-------------------|-------------------|--------|---------|
+| shoulder_pan | (0.039, 0, 0.062) | (π, 0, -π) | Z | -110° ~ +110° |
+| shoulder_lift | (-0.030, -0.018, -0.054) | (-π/2, -π/2, 0) | Z | -100° ~ +100° |
+| elbow_flex | (-0.113, -0.028, 0) | (0, 0, π/2) | Z | -96.8° ~ +96.8° |
+| wrist_flex | (-0.135, 0.005, 0) | (0, 0, -π/2) | Z | -95° ~ +95° |
+| wrist_roll | (0, -0.061, 0.018) | (π/2, 0.049, π) | Z | -157.2° ~ +162.8° |
 
 !!! note "5自由度の制約"
     SO-101はgripperを除くと5自由度です。エンドエフェクタの位置（x, y, z）と姿勢のうち2成分（pitch, roll）を制御できますが、yaw（ヨー）は独立に制御できません。
+
+!!! info "URDF変換の計算"
+    各関節のFK変換は `T = Translation(xyz) @ Rz(yaw) @ Ry(pitch) @ Rx(roll) @ Rz(θ)` で計算されます。ここで θ は関節角度です。
 
 ## :material-gamepad-variant: SpaceMouse による制御 {#spacemouse}
 

--- a/src/robopy/kinematics/transforms.py
+++ b/src/robopy/kinematics/transforms.py
@@ -46,6 +46,19 @@ def translation(x: float, y: float, z: float) -> NDArray[np.float64]:
     return T
 
 
+def urdf_transform(
+    xyz: tuple[float, float, float],
+    rpy: tuple[float, float, float],
+) -> NDArray[np.float64]:
+    """Create a 4x4 transform from URDF joint origin (xyz, rpy).
+
+    The URDF convention is ``T = Translation(xyz) @ Rz(yaw) @ Ry(pitch) @ Rx(roll)``.
+    """
+    x, y, z = xyz
+    roll, pitch, yaw = rpy
+    return translation(x, y, z) @ rot_z(yaw) @ rot_y(pitch) @ rot_x(roll)
+
+
 def pose_from_matrix(T: NDArray[np.float64]) -> NDArray[np.float64]:
     """Extract (x, y, z, pitch, roll) from a 4x4 homogeneous matrix.
 

--- a/tests/test_kinematics/test_robot_chains.py
+++ b/tests/test_kinematics/test_robot_chains.py
@@ -27,6 +27,46 @@ class TestSO101Chain:
         reach = np.linalg.norm(pos)
         assert 0.01 < reach < 0.6, f"Unexpected reach {reach} m at home"
 
+    def test_fk_home_position_values(self):
+        """Home position must match the URDF FK (arm extended forward/up)."""
+        chain = so101_chain()
+        T = chain.forward_kinematics_matrix(np.zeros(5))
+        pos = T[:3, 3]
+        # Expected from URDF: arm extended forward in +X, raised in +Z.
+        np.testing.assert_allclose(pos[0], 0.391, atol=0.005)  # ~0.39 m forward
+        assert pos[0] > 0.3, "Home x must be positive (arm forward)"
+        np.testing.assert_allclose(pos[1], 0.0, atol=0.005)    # centred in Y
+        np.testing.assert_allclose(pos[2], 0.227, atol=0.005)  # ~0.23 m high
+
+    def test_fk_home_all_axes_z(self):
+        """All joints in the SO-101 URDF rotate about local Z."""
+        chain = so101_chain()
+        for j in chain._joints:
+            assert j.axis == "z", f"Joint {j.name} axis should be 'z', got '{j.axis}'"
+
+    def test_shoulder_pan_swings_y(self):
+        """Shoulder pan should swing the EE left/right (±Y)."""
+        chain = so101_chain()
+        home = chain.forward_kinematics(np.zeros(5))
+        q_pos = np.array([0.3, 0, 0, 0, 0])
+        q_neg = np.array([-0.3, 0, 0, 0, 0])
+        pose_pos = chain.forward_kinematics(q_pos)
+        pose_neg = chain.forward_kinematics(q_neg)
+        # +pan → -Y, -pan → +Y (URDF convention)
+        assert pose_pos[1] < home[1], "Positive pan should move EE in -Y"
+        assert pose_neg[1] > home[1], "Negative pan should move EE in +Y"
+        # X/Z should change less than Y
+        assert abs(pose_pos[1] - home[1]) > abs(pose_pos[0] - home[0])
+
+    def test_shoulder_lift_moves_z(self):
+        """Shoulder lift should move the EE up/down (±Z)."""
+        chain = so101_chain()
+        home = chain.forward_kinematics(np.zeros(5))
+        q_neg = np.array([0, -0.3, 0, 0, 0])
+        pose_neg = chain.forward_kinematics(q_neg)
+        # Negative lift → higher Z (arm lifts)
+        assert pose_neg[2] > home[2], "Negative lift should raise EE"
+
     def test_fk_returns_ee_pose(self):
         chain = so101_chain()
         pose = chain.forward_kinematics(np.zeros(5))


### PR DESCRIPTION
The previous implementation used pure translation offsets with simplified axis labels (x/y) for each joint, ignoring the RPY rotations in the URDF joint origins. This caused the FK to compute completely wrong EE positions (e.g. home position was (-0.25, -0.10, -0.07) instead of the correct (0.39, 0.0, 0.23)), making SpaceMouse teleoperation move in wrong directions.

The SO-101 URDF (so101_new_calib.urdf) defines all joints with axis="0 0 1" (local Z), using origin RPY rotations to orient each frame. The fix:

- Add urdf_transform() helper to transforms.py that builds a 4x4 matrix from URDF-style (xyz, rpy) using the standard R = Rz(yaw) @ Ry(pitch) @ Rx(roll)
- Rewrite so101_chain() to use full URDF joint origin transforms (xyz + rpy) instead of pure translations, with all axes set to "z"
- Include the gripper_frame_joint fixed transform RPY (0, π, 0)
- Add regression tests validating home position, joint axis directions, and urdf_transform correctness
- Update docs kinematic parameter table with URDF RPY values

https://claude.ai/code/session_01W5njgeeLC3GK45LNRYMaRj