### PR TITLE
Improve SpaceMouse input handling with smoothing and deadzone remapping

### DIFF
--- a/src/robopy/config/input_config/spacemouse_config.py
+++ b/src/robopy/config/input_config/spacemouse_config.py
@@ -13,6 +13,11 @@ class SpaceMouseConfig:
         gripper_speed: Gripper movement speed in degrees/s per button press.
         deadzone: Axes with absolute values below this threshold are zeroed.
         control_hz: Control loop frequency in Hz.
+        input_smoothing: Exponential moving average factor for SpaceMouse axes.
+            0.0 = no smoothing (raw input), 1.0 = maximum smoothing.
+            Higher values reduce jitter but add latency.
+        max_joint_delta_deg: Maximum allowed joint angle change per control
+            step in degrees.  Prevents vibration from large IK solution jumps.
     """
 
     linear_speed: float = 0.10
@@ -20,3 +25,5 @@ class SpaceMouseConfig:
     gripper_speed: float = 50.0
     deadzone: float = 0.05
     control_hz: int = 50
+    input_smoothing: float = 0.5
+    max_joint_delta_deg: float = 5.0


### PR DESCRIPTION
## Summary
This PR enhances the SpaceMouse controller with improved input processing, including exponential moving average (EMA) smoothing to reduce jitter and proper deadzone remapping to ensure smooth output transitions. It also adds joint velocity clamping to prevent vibration from IK solution jumps.

## Key Changes

- **Deadzone Remapping**: Modified `_apply_deadzone()` to linearly remap values above the deadzone threshold to [0, 1] range instead of passing them through unchanged. This ensures smooth output transitions without discontinuous jumps at the deadzone boundary.

- **Input Smoothing**: Added EMA-based filtering of SpaceMouse axes with configurable `input_smoothing` parameter (0.0-1.0). The filter state is properly initialized and reset at the start of each teleoperation/recording session to prevent stale state carryover.

- **Joint Velocity Clamping**: Implemented per-joint velocity limiting with `max_joint_delta_deg` parameter to prevent large jumps in joint angles from IK solution discontinuities, reducing unwanted vibration.

- **Configuration Updates**: Extended `SpaceMouseConfig` with two new parameters:
  - `input_smoothing`: Controls EMA smoothing strength (default 0.5)
  - `max_joint_delta_deg`: Maximum joint angle change per step in degrees (default 5.0)

- **Test Improvements**: Refactored test suite to use new `_make_controller()` helper function, reducing boilerplate and improving maintainability. Updated deadzone tests to verify the new remapping behavior and added `input_smoothing=0.0` to tests requiring raw input.

## Implementation Details

- Filter state (`_filtered_axes`, `_filter_initialized`) is maintained across control steps but reset via `_reset_filter()` at session start
- EMA formula: `filtered = alpha * raw + (1 - alpha) * previous` where `alpha = 1 - input_smoothing`
- Joint velocity clamping is applied after IK solution but before sending to robot
- All changes are backward compatible with existing code paths

https://claude.ai/code/session_01Nm7SbMTjBvDaMeJKCLz6vF