### PR TITLE
Fix pre-commit hook failures (ruff, ruff-format, mypy)

### DIFF
--- a/docs/api/kinematics.md
+++ b/docs/api/kinematics.md
@@ -1,0 +1,154 @@
+# キネマティクス API
+
+このページでは、Robopyのキネマティクス（運動学）モジュールに関連するAPIを説明します。
+
+## 概要
+
+`robopy.kinematics` モジュールは、5自由度ロボットアームのForward Kinematics (FK) と Inverse Kinematics (IK) を提供します。
+
+- **FK**: 関節角度 → エンドエフェクタ姿勢（位置 + 姿勢）
+- **IK**: エンドエフェクタ姿勢 → 関節角度（数値解法）
+
+外部依存は **numpy のみ** です。scipy は不要です。
+
+## :material-axis-arrow: エンドエフェクタ姿勢
+
+::: robopy.kinematics.ee_pose.EEPose
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - to_array
+        - from_array
+
+## :material-link: キネマティックチェーン
+
+::: robopy.kinematics.chain.RevoluteJoint
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: robopy.kinematics.chain.KinematicChain
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - n_joints
+        - joint_names
+        - lower_limits_rad
+        - upper_limits_rad
+        - forward_kinematics_matrix
+        - forward_kinematics
+        - jacobian
+        - clamp_to_limits
+
+## :material-calculator: IKソルバー
+
+::: robopy.kinematics.ik_solver.IKConfig
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: robopy.kinematics.ik_solver.IKResult
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: robopy.kinematics.ik_solver.IKSolver
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - config
+        - solve
+
+## :material-robot: ロボット固有のチェーン定義
+
+::: robopy.kinematics.robot_chains.so101_chain
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: robopy.kinematics.robot_chains.koch_chain
+    options:
+      show_root_heading: true
+      show_source: true
+
+## アルゴリズム
+
+### Damped Least-Squares (DLS) IK
+
+IKソルバーは **Damped Least-Squares** アルゴリズムを使用しています:
+
+$$
+\Delta q = J_w^T (J_w J_w^T + \lambda^2 I)^{-1} e_w
+$$
+
+ここで:
+
+- $J_w$: 重み付きヤコビアン行列 (5 x n_joints)
+- $e_w$: 重み付きタスク空間誤差 (5,)
+- $\lambda$: ダンピング係数（`IKConfig.damping`）
+- $I$: 単位行列
+
+この手法の特徴:
+
+- 特異姿勢（腕が完全に伸びた状態など）でも安定
+- 位置と姿勢に独立した重みを設定可能
+- 5x5の線形方程式を `np.linalg.solve` で解くため高速
+- scipy 不要（numpy のみ）
+
+### 数値ヤコビアン
+
+ヤコビアンは中心差分法で計算されます:
+
+$$
+J_{ij} = \frac{f(q + \delta e_j) - f(q - \delta e_j)}{2\delta}
+$$
+
+5関節の場合、1回のヤコビアン計算に10回のFK評価が必要ですが、各FKは5回の4x4行列乗算のみなので100Hzの制御ループでも十分高速です。
+
+## 使用例
+
+### オフラインでのFK/IK計算
+
+ハードウェア接続なしでFK/IK計算を行う例:
+
+```python
+import numpy as np
+from robopy.kinematics import so101_chain, koch_chain, IKSolver, IKConfig
+
+# SO-101のチェーンを作成
+chain = so101_chain()
+
+# 全関節0度でのEE位置を確認
+home_pose = chain.forward_kinematics(np.zeros(5))
+print(f"Home位置: x={home_pose[0]:.4f}, y={home_pose[1]:.4f}, z={home_pose[2]:.4f}")
+
+# IKで目標姿勢に到達する関節角度を求める
+solver = IKSolver(chain, IKConfig(max_iterations=200))
+result = solver.solve(
+    target_pose=home_pose,
+    initial_angles_rad=np.zeros(5),
+)
+print(f"収束: {result.success}, 反復回数: {result.iterations}")
+```
+
+### ロボットクラスからの利用
+
+```python
+from robopy.robots.so101.so101_robot import So101Robot
+from robopy.kinematics import EEPose
+import numpy as np
+
+# FK（classmethodなのでインスタンス不要）
+joint_angles = np.array([0.0, 30.0, -45.0, 20.0, 0.0, 50.0], dtype=np.float32)
+ee_pose = So101Robot.forward_kinematics(joint_angles)
+
+# IK（接続済みロボットで）
+# target = EEPose(x=0.1, y=0.0, z=0.15, pitch=0.0, roll=0.0)
+# result = robot.inverse_kinematics(target, current_joints)
+
+# EEアクション送信（接続済みロボットで）
+# robot.send_ee_frame_action(np.array([0.1, 0.0, 0.15, 0.0, 0.0, 50.0]))
+```

--- a/docs/api/robots.md
+++ b/docs/api/robots.md
@@ -82,6 +82,21 @@
 
 ::: robopy.config.robot_config.so101_config.So101Config
 
+## :material-gamepad-variant: So101SpaceMouseController
+
+SpaceMouseを使用したEE空間テレオペレーション。詳細は[SpaceMouse API](spacemouse.md)を参照。
+
+::: robopy.robots.so101.so101_spacemouse.So101SpaceMouseController
+    options:
+      show_root_heading: true
+      show_source: false
+      members:
+        - __init__
+        - connect
+        - disconnect
+        - teleoperation
+        - record_parallel
+
 ## 使用例
 
 ### 基本的なRakudaRobotの使用

--- a/docs/api/robots.md
+++ b/docs/api/robots.md
@@ -57,6 +57,30 @@
         - connect
         - disconnect
         - teleoperation
+        - forward_kinematics
+        - inverse_kinematics
+        - send_frame_action
+        - send_ee_frame_action
+        - send_ee
+
+## :material-robot: So101Robot
+
+::: robopy.robots.so101.so101_robot.So101Robot
+    options:
+      show_root_heading: true
+      show_source: false
+      members:
+        - __init__
+        - connect
+        - disconnect
+        - teleoperation
+        - forward_kinematics
+        - inverse_kinematics
+        - send_frame_action
+        - send_ee_frame_action
+        - send_ee
+
+::: robopy.config.robot_config.so101_config.So101Config
 
 ## 使用例
 

--- a/docs/api/spacemouse.md
+++ b/docs/api/spacemouse.md
@@ -1,0 +1,139 @@
+# SpaceMouse API
+
+このページでは、SpaceMouse による SO-101 制御に関連する API を説明します。
+
+## 概要
+
+SpaceMouse 統合は以下のコンポーネントで構成されます:
+
+- **SpaceMouseReader**: `pyspacemouse` のスレッドベースラッパー。デバイスをバックグラウンドでポーリングし、最新の 6-DOF 状態を提供
+- **SpaceMouseConfig**: 速度スケーリング、デッドゾーン等の設定
+- **So101SpaceMouseController**: SpaceMouse → EE デルタ → IK → Follower の制御パイプライン
+- **So101SpaceMouseExpHandler**: データ収集用の対話的ハンドラ
+
+```mermaid
+graph TD
+    A[SpaceMouseReader] -->|SpaceMouseState| B[So101SpaceMouseController]
+    C[SpaceMouseConfig] --> B
+    D[So101Robot] --> B
+    B -->|So101Obs| E[So101SpaceMouseExpHandler]
+    E -->|HDF5/GIF| F[So101SaveWorker]
+```
+
+## :material-gamepad-variant: 入力デバイス
+
+### SpaceMouseState {#spacemousestate}
+
+::: robopy.input.spacemouse.SpaceMouseState
+    options:
+      show_root_heading: true
+      show_source: true
+
+### SpaceMouseReader {#spacemousereader}
+
+::: robopy.input.spacemouse.SpaceMouseReader
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - start
+        - stop
+        - get_state
+        - is_running
+
+## :material-cog: 設定
+
+### SpaceMouseConfig {#spacemouseconfig}
+
+::: robopy.config.input_config.spacemouse_config.SpaceMouseConfig
+    options:
+      show_root_heading: true
+      show_source: true
+
+## :material-robot: コントローラー
+
+### So101SpaceMouseController {#so101spacemousecontroller}
+
+::: robopy.robots.so101.so101_spacemouse.So101SpaceMouseController
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - __init__
+        - connect
+        - disconnect
+        - teleoperation
+        - record_parallel
+        - robot
+        - is_connected
+
+## :material-flask: 実験ハンドラ
+
+### So101SpaceMouseExpHandler {#so101spacemouseexphandler}
+
+::: robopy.utils.exp_interface.so101_spacemouse_exp_handler.So101SpaceMouseExpHandler
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - __init__
+        - record
+        - send
+        - record_save
+        - close
+        - controller
+
+## 使用例
+
+### 基本的なテレオペレーション
+
+```python
+from robopy.config.robot_config.so101_config import So101Config
+from robopy.robots.so101.so101_robot import So101Robot
+from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+config = So101Config(
+    follower_port="/dev/ttyACM0",
+    calibration_path="calibration/so101_calib.pkl",
+)
+
+robot = So101Robot(cfg=config)
+controller = So101SpaceMouseController(robot)
+controller.connect()
+
+# 30秒間操作
+controller.teleoperation(max_seconds=30)
+controller.disconnect()
+```
+
+### カスタム設定でのデータ収集
+
+```python
+from robopy.config.input_config.spacemouse_config import SpaceMouseConfig
+
+sm_config = SpaceMouseConfig(
+    linear_speed=0.05,   # 低速で精密操作
+    angular_speed=0.3,
+    deadzone=0.08,       # 大きめのデッドゾーン
+    control_hz=100,      # 高速な制御ループ
+)
+
+controller = So101SpaceMouseController(robot, spacemouse_config=sm_config)
+controller.connect()
+
+obs = controller.record_parallel(max_frame=1000, fps=30)
+```
+
+### EE デルタの計算式
+
+各制御ステップで、SpaceMouse の軸値から EE デルタを計算します:
+
+$$
+\Delta x = \text{axis}_x \times \text{linear\_speed} \times dt
+$$
+
+$$
+\Delta \text{pitch} = \text{axis}_\text{pitch} \times \text{angular\_speed} \times dt
+$$
+
+ここで $dt = 1 / \text{control\_hz}$ です。デッドゾーン内の軸値（$|\text{axis}| < \text{deadzone}$）はゼロとして扱われます。

--- a/docs/api/spacemouse.md
+++ b/docs/api/spacemouse.md
@@ -94,7 +94,7 @@ from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
 
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 
 robot = So101Robot(cfg=config)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Robopy Documentation
 
-**Robopy**は、ロボット制御のためのPython interfaceです。rakuda と koch robotに対応し、カメラと触覚センサーを統合したデータ収集をサポートします。
+**Robopy**は、ロボット制御のためのPython interfaceです。Rakuda、Koch、SO-101 robotに対応し、カメラと触覚センサーを統合したデータ収集をサポートします。Forward Kinematics / Inverse Kinematics によるエンドエフェクタ空間での制御も可能です。
 
 ## :material-book-open: ドキュメント構成
 
@@ -23,6 +23,7 @@
 
     [:octicons-arrow-right-24: Rakuda](robots/rakuda.md)
     [:octicons-arrow-right-24: Koch](robots/koch.md)
+    [:octicons-arrow-right-24: SO-101](robots/so101.md)
 
 -   :material-camera: **センサー**
 
@@ -48,6 +49,7 @@
     詳細なAPI仕様
 
     [:octicons-arrow-right-24: ロボット](api/robots.md)
+    [:octicons-arrow-right-24: キネマティクス](api/kinematics.md)
     [:octicons-arrow-right-24: センサー](api/sensors.md)
 
 -   :material-devices: **開発者向け**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Robopy Documentation
 
-**Robopy**は、ロボット制御のためのPython interfaceです。Rakuda、Koch、SO-101 robotに対応し、カメラと触覚センサーを統合したデータ収集をサポートします。Forward Kinematics / Inverse Kinematics によるエンドエフェクタ空間での制御も可能です。
+**Robopy**は、ロボット制御のためのPython interfaceです。Rakuda、Koch、SO-101 robotに対応し、カメラと触覚センサーを統合したデータ収集をサポートします。Forward Kinematics / Inverse Kinematics によるエンドエフェクタ空間での制御、SpaceMouse によるテレオペレーションとデータ収集も可能です。
 
 ## :material-book-open: ドキュメント構成
 
@@ -49,6 +49,7 @@
     詳細なAPI仕様
 
     [:octicons-arrow-right-24: ロボット](api/robots.md)
+    [:octicons-arrow-right-24: SpaceMouse](api/spacemouse.md)
     [:octicons-arrow-right-24: キネマティクス](api/kinematics.md)
     [:octicons-arrow-right-24: センサー](api/sensors.md)
 

--- a/docs/robots/koch.md
+++ b/docs/robots/koch.md
@@ -1,6 +1,6 @@
 # Koch Robot
 
-[`KochRobot`](../api/robots.md#robopy.robots.koch.koch_robot.KochRobot)は、二腕ロボットシステムでカメラセンサーを統合したロボットです。
+[`KochRobot`](../api/robots.md#robopy.robots.koch.koch_robot.KochRobot)は、Dynamixel X-Seriesサーボモーターを使用した6軸二腕ロボットシステムです。
 
 ## :material-robot-outline: 構成要素
 
@@ -8,6 +8,17 @@
 
 - **Leader Arm**: 操作者が制御するアーム
 - **Follower Arm**: Leaderの動きを追従するアーム
+
+各アームは6つの関節で構成されています:
+
+| 関節名 | 機能 |
+|--------|------|
+| `shoulder_pan` | 肩の水平回転 |
+| `shoulder_lift` | 肩の上下回転 |
+| `elbow` | 肘の屈伸 |
+| `wrist_flex` | 手首の屈伸 |
+| `wrist_roll` | 手首の回転 |
+| `gripper` | グリッパーの開閉 |
 
 ### センサー統合
 
@@ -24,26 +35,25 @@ from robopy.config.robot_config.koch_config import KochConfig
 config = KochConfig(
     leader_port="/dev/ttyUSB0",
     follower_port="/dev/ttyUSB1",
-    camera_config=None  # カメラなし
+    calibration_path="calibration/koch_calib.pkl",
 )
 ```
 
 ### カメラ付きの設定
 
 ```python
-from robopy.config.robot_config.koch_config import KochConfig
-from robopy.config.sensor_config.visual_config import WebCameraConfig
+from robopy.config.robot_config.koch_config import KochConfig, KochSensorConfig
+from robopy.config.sensor_config.visual_config.camera_config import WebCameraConfig
 
-# Webカメラ付き設定
 config = KochConfig(
     leader_port="/dev/ttyUSB0",
     follower_port="/dev/ttyUSB1",
-    camera_config=WebCameraConfig(
-        device_id=0,
-        fps=20,
-        width=640,
-        height=480
-    )
+    calibration_path="calibration/koch_calib.pkl",
+    sensors=KochSensorConfig(
+        cameras={
+            "top": WebCameraConfig(fps=30, width=640, height=480),
+        }
+    ),
 )
 ```
 
@@ -59,7 +69,7 @@ try:
     robot.connect()
 
     # テレオペレーション（10秒間）
-    robot.teleoperation(duration=10)
+    robot.teleoperation(max_seconds=10)
 
 finally:
     robot.disconnect()
@@ -72,28 +82,117 @@ finally:
 obs = robot.record(max_frame=100, fps=5)
 
 # 記録されたデータの確認
-print(f"Leader アーム: {obs['arms']['leader'].shape}")
-print(f"Follower アーム: {obs['arms']['follower'].shape}")
-
-if obs['camera'] is not None:
-    print(f"カメラ: {obs['camera'].shape}")
+print(f"Leader アーム: {obs.arms.leader.shape}")     # (frames, 6)
+print(f"Follower アーム: {obs.arms.follower.shape}")  # (frames, 6)
 ```
 
-### 記録データ構造
-
-記録されるデータは[`KochObs`](../api/config.md#robopy.config.robot_config.koch_config.KochObs)型で、以下の構造を持ちます：
+### 高速並列記録
 
 ```python
-{
-    "arms": {
-        "leader": np.ndarray,    # (frames, joint_dims) - 関節角度など
-        "follower": np.ndarray,  # (frames, joint_dims) - 関節角度など
-    },
-    "camera": np.ndarray | None,  # (frames, H, W, C) - RGB画像 or None
-}
+obs = robot.record_parallel(
+    max_frame=500,
+    fps=20,
+    teleop_hz=25,
+)
 ```
+
+## :material-play: アクションの送信
+
+### 関節空間でのアクション送信
+
+```python
+import numpy as np
+
+# 関節角度の軌道を再生
+robot.send(
+    max_frame=100,
+    fps=20,
+    leader_action=recorded_joint_trajectory,
+    teleop_hz=100,
+)
+
+# 1フレームだけ送信
+robot.send_frame_action(np.array([0.0, 30.0, -45.0, 20.0, 0.0, 50.0]))
+```
+
+### エンドエフェクタ空間でのアクション送信
+
+Inverse Kinematics (IK) を使用して、エンドエフェクタの姿勢を指定してロボットを制御できます。詳細は[キネマティクス](#kinematics)セクションを参照してください。
+
+```python
+import numpy as np
+
+# エンドエフェクタ姿勢: [x, y, z, pitch, roll, gripper_deg]
+ee_action = np.array([0.1, 0.0, 0.1, 0.0, 0.0, 50.0], dtype=np.float32)
+robot.send_ee_frame_action(ee_action)
+```
+
+## :material-axis-arrow: キネマティクス {#kinematics}
+
+KochRobotにもForward Kinematics (FK) と Inverse Kinematics (IK) が組み込まれています。使い方は[SO-101](so101.md#kinematics)と同じインターフェースです。
+
+!!! warning "物理パラメータは推定値です"
+    Koch v1.1には公式のURDFが存在しません。現在のキネマティクスパラメータはMuJoCo menagerieとCAD図面からの**推定値**です。実機で使用する前に、実測値で置き換えてください。対応するパラメータは `robopy.kinematics.robot_chains.koch_chain` に `TODO(physical-params)` マーカーで示されています。
+
+### Forward Kinematics (FK)
+
+```python
+import numpy as np
+from robopy.robots.koch.koch_robot import KochRobot
+
+# @classmethod: ハードウェア接続なしで使用可能
+joint_angles = np.array([0.0, 30.0, -45.0, 20.0, 0.0, 50.0], dtype=np.float32)
+ee_pose = KochRobot.forward_kinematics(joint_angles)
+
+print(f"位置: x={ee_pose.x:.4f} m, y={ee_pose.y:.4f} m, z={ee_pose.z:.4f} m")
+print(f"姿勢: pitch={np.rad2deg(ee_pose.pitch):.1f}°, roll={np.rad2deg(ee_pose.roll):.1f}°")
+```
+
+### Inverse Kinematics (IK)
+
+```python
+from robopy.kinematics import EEPose
+
+target = EEPose(x=0.1, y=0.0, z=0.1, pitch=0.0, roll=0.0)
+current_joints = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+result = robot.inverse_kinematics(target, current_joints)
+print(f"収束: {result.success}")
+print(f"位置誤差: {result.position_error:.6f} m")
+```
+
+### キネマティックチェーンの直接利用
+
+```python
+from robopy.kinematics import koch_chain, IKSolver
+import numpy as np
+
+chain = koch_chain()
+solver = IKSolver(chain)
+
+# FK: 関節角度（ラジアン）→ 姿勢
+q = np.zeros(5)
+pose = chain.forward_kinematics(q)
+
+# IK: 姿勢 → 関節角度
+result = solver.solve(target_pose=pose, initial_angles_rad=q)
+```
+
+### Koch のキネマティックパラメータ（推定値）
+
+| 関節 | オフセット (m) | 回転軸 | 可動範囲 |
+|------|---------------|--------|---------|
+| shoulder_pan | (0, 0, 0.05) | Y | -150° ~ +150° |
+| shoulder_lift | (0, 0, -0.04) | X | -100° ~ +100° |
+| elbow | (-0.110, 0, 0) | X | -100° ~ +100° |
+| wrist_flex | (-0.100, 0, 0) | X | -100° ~ +100° |
+| wrist_roll | (0, -0.04, 0) | Y | -180° ~ +180° |
+
+!!! note "5自由度の制約"
+    Koch もgripperを除くと5自由度です。エンドエフェクタの位置（x, y, z）と姿勢のうち2成分（pitch, roll）を制御できますが、yaw（ヨー）は独立に制御できません。
 
 ## :material-link-variant: 関連クラス
 
 - [`KochConfig`](../api/config.md#robopy.config.robot_config.koch_config.KochConfig) - ロボット設定
-- [`KochObs`](../api/config.md#robopy.config.robot_config.koch_config.KochObs) - 観測データ型
+- [`EEPose`](../api/kinematics.md) - エンドエフェクタ姿勢
+- [`IKSolver`](../api/kinematics.md) - 逆運動学ソルバー

--- a/docs/robots/so101.md
+++ b/docs/robots/so101.md
@@ -256,10 +256,245 @@ graph LR
 !!! note "5自由度の制約"
     SO-101はgripperを除くと5自由度です。エンドエフェクタの位置（x, y, z）と姿勢のうち2成分（pitch, roll）を制御できますが、yaw（ヨー）は独立に制御できません。
 
+## :material-gamepad-variant: SpaceMouse による制御 {#spacemouse}
+
+3Dconnexion SpaceMouse を使用して、エンドエフェクタ空間でSO-101を直感的に制御できます。Leaderアームの代わりにSpaceMouseをテレオペレーションの入力デバイスとして使用し、データ収集も可能です。
+
+### 動作原理
+
+SpaceMouseの6軸入力（x, y, z, roll, pitch, yaw）は**エンドエフェクタ姿勢の変化量（デルタ）**として扱われます。各制御ステップで:
+
+1. SpaceMouseの軸値（[-1, 1]に正規化）を読み取る
+2. デッドゾーンを適用（微小な入力をフィルタ）
+3. 速度スケーリングとdtを掛けてEEデルタを計算
+4. 現在のEE目標姿勢にデルタを加算
+5. IKで関節角度に変換し、Followerに送信
+
+```mermaid
+graph LR
+    A[SpaceMouse<br/>6-DOF入力] -->|"[-1, 1]"| B[デッドゾーン<br/>フィルタ]
+    B -->|"速度 × dt"| C[EE デルタ<br/>Δx,Δy,Δz,Δpitch,Δroll]
+    C -->|"現在EE + Δ"| D[IK ソルバー]
+    D -->|"関節角度"| E[Follower<br/>モーター]
+    F[ボタン L/R] -->|"開閉"| G[グリッパー]
+```
+
+!!! info "EEデルタ方式"
+    SpaceMouseの入力は**絶対姿勢ではなく、姿勢の変化量**として扱います。これにより:
+
+    - 操作開始時のロボット姿勢に関係なく直感的に操作できる
+    - 小さな入力で微細な動きを実現できる
+    - 入力がゼロのとき、ロボットは静止する
+
+### インストール
+
+SpaceMouse サポートはオプション依存です:
+
+```bash
+# uv を使用
+uv sync --group spacemouse
+
+# pip を使用
+pip install pyspacemouse
+```
+
+!!! warning "Linuxでの権限設定"
+    Linux環境ではSpaceMouseデバイスへのアクセスに udev ルールの設定が必要な場合があります。`pyspacemouse` の[セットアップガイド](https://github.com/JakubAndrworksysek/PySpaceMouse)を参照してください。
+
+### 基本的なテレオペレーション
+
+```python
+from robopy.config.robot_config.so101_config import So101Config
+from robopy.robots.so101.so101_robot import So101Robot
+from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+# Followerのみの設定（Leaderアーム不要）
+config = So101Config(
+    follower_port="/dev/ttyACM0",
+    calibration_path="calibration/so101_calib.pkl",
+)
+
+robot = So101Robot(cfg=config)
+controller = So101SpaceMouseController(robot)
+
+try:
+    # ロボット接続 + SpaceMouse起動
+    controller.connect()
+
+    # SpaceMouseで30秒間テレオペレーション
+    controller.teleoperation(max_seconds=30)
+
+    # 時間制限なし（Ctrl+C で停止）
+    # controller.teleoperation()
+
+finally:
+    controller.disconnect()
+```
+
+### 速度・感度の調整
+
+`SpaceMouseConfig` で操作感をカスタマイズできます。
+
+```python
+from robopy.config.input_config.spacemouse_config import SpaceMouseConfig
+
+config = SpaceMouseConfig(
+    linear_speed=0.10,     # 並進速度: SpaceMouse 1.0 → 0.10 m/s
+    angular_speed=0.5,     # 回転速度: SpaceMouse 1.0 → 0.5 rad/s
+    gripper_speed=50.0,    # グリッパー速度: 50 deg/s per button
+    deadzone=0.05,         # デッドゾーン: |axis| < 0.05 → 0
+    control_hz=50,         # 制御ループ周波数
+)
+
+controller = So101SpaceMouseController(robot, spacemouse_config=config)
+```
+
+| パラメータ | デフォルト | 説明 |
+|-----------|-----------|------|
+| `linear_speed` | 0.10 m/s | 並進方向の最大速度 |
+| `angular_speed` | 0.5 rad/s | 回転方向の最大速度 |
+| `gripper_speed` | 50.0 deg/s | グリッパー開閉速度 |
+| `deadzone` | 0.05 | 入力のデッドゾーン閾値 |
+| `control_hz` | 50 Hz | 制御ループの周波数 |
+
+!!! tip "操作のコツ"
+    - `linear_speed` を小さくすると精密な位置決めが楽になります
+    - `deadzone` を大きくすると不意な動きを防げます
+    - グリッパーは**左ボタンで閉じ**、**右ボタンで開き**ます
+
+### グリッパー操作
+
+SpaceMouseのボタンでグリッパーを制御します:
+
+| ボタン | 動作 |
+|--------|------|
+| 左ボタン | グリッパーを閉じる（角度減少） |
+| 右ボタン | グリッパーを開く（角度増加） |
+
+グリッパー角度は 0° ～ 100° にクランプされます。
+
+### データ収集（記録）
+
+SpaceMouseでロボットを操作しながら、関節角度とカメラ画像を記録できます。記録されたデータは既存の再生パイプライン（`So101Robot.send()`）と互換性があります。
+
+```python
+from robopy.config.sensor_config.visual_config.camera_config import WebCameraConfig
+from robopy.config.robot_config.so101_config import So101Config, So101SensorConfig
+
+# カメラ付き設定
+config = So101Config(
+    follower_port="/dev/ttyACM0",
+    calibration_path="calibration/so101_calib.pkl",
+    sensors=So101SensorConfig(
+        cameras={
+            "top": WebCameraConfig(fps=30, width=640, height=480),
+        }
+    ),
+)
+
+robot = So101Robot(cfg=config)
+controller = So101SpaceMouseController(robot)
+controller.connect()
+
+# SpaceMouse操作を記録
+obs = controller.record_parallel(
+    max_frame=500,       # 記録フレーム数
+    fps=20,              # カメラキャプチャレート
+    control_hz=50,       # SpaceMouse制御レート（fpsより高くする）
+)
+
+print(f"Leader (指令値): {obs.arms.leader.shape}")    # (500, 6)
+print(f"Follower (実測値): {obs.arms.follower.shape}")  # (500, 6)
+for name, frames in obs.cameras.items():
+    if frames is not None:
+        print(f"Camera {name}: {frames.shape}")
+```
+
+!!! info "記録データの内容"
+    - **`arms.leader`**: IKで計算された関節角度の指令値（6要素: 5関節 + gripper）
+    - **`arms.follower`**: Followerモーターの実際の読み値
+    - **`cameras`**: カメラフレーム
+
+    `leader` データは `So101Robot.send()` でそのまま再生可能です。
+
+### ExpHandler を使用した対話的データ収集
+
+`So101SpaceMouseExpHandler` を使えば、warmup → 記録 → 保存の対話的ワークフローが利用できます。
+
+```python
+from robopy.utils.exp_interface.so101_spacemouse_exp_handler import (
+    So101SpaceMouseExpHandler,
+)
+from robopy.utils.exp_interface.meta_data_config import MetaDataConfig
+
+metadata = MetaDataConfig(
+    task_name="pick_and_place",
+    description="SpaceMouse teleoperation demo",
+)
+
+handler = So101SpaceMouseExpHandler(
+    so101_config=config,
+    metadata_config=metadata,
+    fps=20,
+)
+
+# 対話的ループ: warmup → 記録 → 保存を繰り返す
+handler.record_save(
+    max_frames=500,
+    save_path="spacemouse_demo",
+    save_gif=True,
+    warmup_time=5,
+)
+```
+
+ワークフロー:
+
+1. **Enter** → SpaceMouseで5秒間ウォームアップ
+2. **Enter** → 記録開始（SpaceMouseで操作）
+3. 記録完了後:
+    - **1~9** → データを保存（HDF5 + GIF）
+    - **e** → 再記録
+    - **q** → 終了
+
+保存先ディレクトリ構成:
+```
+data/spacemouse_demo/1_1/
+├── so101_observations.h5    # 全データ（HDF5）
+├── arm/
+│   └── so101_arm_observations.h5  # アームデータ
+├── camera_gif/
+│   └── top/
+│       └── top.gif          # カメラ動画
+└── metadata.json            # メタデータ
+```
+
+### 記録データの再生
+
+SpaceMouseで記録したデータをFollowerアームで再生:
+
+```python
+import h5py
+import numpy as np
+
+# HDF5からデータ読み込み
+with h5py.File("data/spacemouse_demo/1_1/arm/so101_arm_observations.h5", "r") as f:
+    leader_actions = np.array(f["arm"]["leader"], dtype=np.float32)
+
+# 再生
+robot.send(
+    max_frame=len(leader_actions),
+    fps=20,
+    leader_action=leader_actions,
+    teleop_hz=100,
+)
+```
+
 ## :material-link-variant: 関連クラス
 
 - [`So101Config`](../api/robots.md) - ロボット設定
 - [`So101PairSys`](../api/robots.md) - Leader-Followerペアシステム
+- [`So101SpaceMouseController`](../api/spacemouse.md) - SpaceMouseコントローラー
+- [`SpaceMouseConfig`](../api/spacemouse.md#spacemouseconfig) - SpaceMouse設定
 - [`EEPose`](../api/kinematics.md) - エンドエフェクタ姿勢
 - [`IKSolver`](../api/kinematics.md) - 逆運動学ソルバー
 - [`KinematicChain`](../api/kinematics.md) - キネマティックチェーン

--- a/docs/robots/so101.md
+++ b/docs/robots/so101.md
@@ -1,0 +1,265 @@
+# SO-101 Robot
+
+[`So101Robot`](../api/robots.md#robopy.robots.so101.so101_robot.So101Robot)は、Feetech STS3215サーボモーターを使用した6軸二腕ロボットシステムです。
+
+## :material-robot-outline: 構成要素
+
+### ロボットアーム
+
+- **Leader Arm**: 操作者が制御するアーム（テレオペレーション用）
+- **Follower Arm**: Leaderの動きを追従するアーム
+
+各アームは6つの関節で構成されています:
+
+| 関節名 | 機能 |
+|--------|------|
+| `shoulder_pan` | 肩の水平回転 |
+| `shoulder_lift` | 肩の上下回転 |
+| `elbow_flex` | 肘の屈伸 |
+| `wrist_flex` | 手首の屈伸 |
+| `wrist_roll` | 手首の回転 |
+| `gripper` | グリッパーの開閉 |
+
+### センサー統合
+
+- **カメラ**: Webカメラ または Intel RealSenseカメラ対応
+
+## :material-cog: 基本的な使用方法
+
+### 設定の作成
+
+```python
+from robopy.config.robot_config.so101_config import So101Config
+
+# 基本設定（Followerのみ、Leaderなし）
+config = So101Config(
+    follower_port="/dev/ttyACM0",
+    calibration_path="calibration/so101_calib.pkl",
+)
+
+# Leader付き設定（テレオペレーション用）
+config = So101Config(
+    leader_port="/dev/ttyACM0",
+    follower_port="/dev/ttyACM1",
+    calibration_path="calibration/so101_calib.pkl",
+)
+```
+
+### カメラ付きの設定
+
+```python
+from robopy.config.robot_config.so101_config import So101Config, So101SensorConfig
+from robopy.config.sensor_config.visual_config.camera_config import WebCameraConfig
+
+config = So101Config(
+    follower_port="/dev/ttyACM0",
+    calibration_path="calibration/so101_calib.pkl",
+    sensors=So101SensorConfig(
+        cameras={
+            "top": WebCameraConfig(fps=30, width=640, height=480),
+        }
+    ),
+)
+```
+
+### ロボットの操作
+
+```python
+from robopy.robots.so101.so101_robot import So101Robot
+
+robot = So101Robot(config)
+
+try:
+    # 接続（初回はキャリブレーションが実行されます）
+    robot.connect()
+
+    # テレオペレーション（10秒間）
+    robot.teleoperation(max_seconds=10)
+
+finally:
+    robot.disconnect()
+```
+
+## :material-database: データ記録
+
+```python
+# 基本的なデータ記録
+obs = robot.record(max_frame=100, fps=5)
+
+# 記録されたデータの確認
+print(f"Leader アーム: {obs.arms.leader.shape}")     # (frames, 6)
+print(f"Follower アーム: {obs.arms.follower.shape}")  # (frames, 6)
+```
+
+### 高速並列記録
+
+```python
+# テレオペレーションとカメラ取得を並列実行
+obs = robot.record_parallel(
+    max_frame=500,
+    fps=20,
+    teleop_hz=25,
+)
+```
+
+## :material-play: アクションの送信
+
+### 関節空間でのアクション送信
+
+記録した関節角度の軌道をそのまま再生できます。
+
+```python
+import numpy as np
+
+# leader_action: (frames, 6) の関節角度配列（度数）
+robot.send(
+    max_frame=100,
+    fps=20,
+    leader_action=recorded_joint_trajectory,
+    teleop_hz=100,
+)
+
+# 1フレームだけ送信
+robot.send_frame_action(np.array([0.0, 30.0, -45.0, 20.0, 0.0, 50.0]))
+```
+
+### エンドエフェクタ空間でのアクション送信
+
+Inverse Kinematics (IK) を使用して、エンドエフェクタの姿勢を指定してロボットを制御できます。詳細は[キネマティクス](#kinematics)セクションを参照してください。
+
+```python
+import numpy as np
+
+# エンドエフェクタ姿勢: [x, y, z, pitch, roll, gripper_deg]
+ee_action = np.array([0.1, 0.0, 0.15, 0.0, 0.0, 50.0], dtype=np.float32)
+robot.send_ee_frame_action(ee_action)
+
+# 軌道として送信
+ee_trajectory = np.zeros((50, 6), dtype=np.float32)
+# ... 軌道を設定 ...
+robot.send_ee(max_frame=50, fps=20, ee_actions=ee_trajectory)
+```
+
+## :material-axis-arrow: キネマティクス {#kinematics}
+
+SO-101は5自由度（gripper除く）のシリアルリンクアームです。`So101Robot`にはForward Kinematics (FK) と Inverse Kinematics (IK) が組み込まれています。
+
+### Forward Kinematics (FK)
+
+関節角度からエンドエフェクタの姿勢を計算します。`@classmethod`なのでハードウェア接続なしで使用可能です。
+
+```python
+import numpy as np
+from robopy.robots.so101.so101_robot import So101Robot
+
+# 関節角度（度数）→ エンドエフェクタ姿勢
+joint_angles = np.array([0.0, 30.0, -45.0, 20.0, 0.0, 50.0], dtype=np.float32)
+ee_pose = So101Robot.forward_kinematics(joint_angles)
+
+print(f"位置: x={ee_pose.x:.4f} m, y={ee_pose.y:.4f} m, z={ee_pose.z:.4f} m")
+print(f"姿勢: pitch={np.rad2deg(ee_pose.pitch):.1f}°, roll={np.rad2deg(ee_pose.roll):.1f}°")
+```
+
+!!! info "入力形式"
+    - (5,) 配列: 5関節の角度（gripper なし）
+    - (6,) 配列: 6関節の角度（最後の gripper は無視される）
+
+### Inverse Kinematics (IK)
+
+目標のエンドエフェクタ姿勢から関節角度を求めます。Damped Least-Squares アルゴリズムを使用しています。
+
+```python
+from robopy.kinematics import EEPose, IKConfig
+
+# 方法1: EEPoseオブジェクトで指定
+target = EEPose(x=0.1, y=0.0, z=0.15, pitch=0.0, roll=0.0)
+current_joints = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+result = robot.inverse_kinematics(target, current_joints)
+print(f"収束: {result.success}")
+print(f"関節角度 (rad): {result.joint_angles_rad}")
+print(f"位置誤差: {result.position_error:.6f} m")
+
+# 方法2: numpy配列で指定
+target_array = np.array([0.1, 0.0, 0.15, 0.0, 0.0], dtype=np.float32)
+result = robot.inverse_kinematics(target_array, current_joints)
+```
+
+### IKパラメータの調整
+
+IKソルバーの挙動はカスタマイズできます。
+
+```python
+from robopy.kinematics import IKConfig
+
+config = IKConfig(
+    max_iterations=200,           # 最大反復回数
+    position_tolerance=1e-4,      # 位置収束閾値 (m)
+    orientation_tolerance=1e-3,   # 姿勢収束閾値 (rad)
+    damping=0.05,                 # ダンピング係数（大きいほど安定）
+    position_weight=1.0,          # 位置の重み
+    orientation_weight=0.1,       # 姿勢の重み
+)
+
+result = robot.inverse_kinematics(target, current_joints, ik_config=config)
+```
+
+!!! tip "位置優先 vs 姿勢優先"
+    `position_weight` と `orientation_weight` の比率を変えることで、位置精度と姿勢精度のバランスを調整できます。デフォルト設定では位置精度を優先しています。
+
+### キネマティックチェーンの直接利用
+
+ハードウェア接続なしでFK/IKの計算のみ行いたい場合:
+
+```python
+from robopy.kinematics import so101_chain, IKSolver
+import numpy as np
+
+# チェーンとソルバーを作成
+chain = so101_chain()
+solver = IKSolver(chain)
+
+# FK: 関節角度（ラジアン）→ 姿勢
+q = np.zeros(5)
+pose = chain.forward_kinematics(q)
+print(f"Home位置: {pose[:3]}")
+
+# IK: 姿勢 → 関節角度
+result = solver.solve(target_pose=pose, initial_angles_rad=q)
+
+# 4x4同次変換行列も取得可能
+T = chain.forward_kinematics_matrix(q)
+```
+
+### SO-101 のキネマティックパラメータ
+
+SO-101の物理パラメータは[SO-ARM100のURDF](https://github.com/TheRobotStudio/SO-ARM100)から取得しています。
+
+```mermaid
+graph LR
+    A[Base] -->|"(0.039, 0, 0.062) m"| B[Shoulder Pan<br/>Y軸回転]
+    B -->|"(-0.030, -0.018, -0.054) m"| C[Shoulder Lift<br/>X軸回転]
+    C -->|"(-0.113, -0.028, 0) m"| D[Elbow Flex<br/>X軸回転]
+    D -->|"(-0.135, 0.005, 0) m"| E[Wrist Flex<br/>X軸回転]
+    E -->|"(0, -0.061, 0.018) m"| F[Wrist Roll<br/>Y軸回転]
+    F -->|"(-0.008, 0, -0.098) m"| G[EE Frame]
+```
+
+| 関節 | オフセット (m) | 回転軸 | 可動範囲 |
+|------|---------------|--------|---------|
+| shoulder_pan | (0.039, 0, 0.062) | Y | -110° ~ +110° |
+| shoulder_lift | (-0.030, -0.018, -0.054) | X | -100° ~ +100° |
+| elbow_flex | (-0.113, -0.028, 0) | X | -96.8° ~ +96.8° |
+| wrist_flex | (-0.135, 0.005, 0) | X | -95° ~ +95° |
+| wrist_roll | (0, -0.061, 0.018) | Y | -157.2° ~ +162.8° |
+
+!!! note "5自由度の制約"
+    SO-101はgripperを除くと5自由度です。エンドエフェクタの位置（x, y, z）と姿勢のうち2成分（pitch, roll）を制御できますが、yaw（ヨー）は独立に制御できません。
+
+## :material-link-variant: 関連クラス
+
+- [`So101Config`](../api/robots.md) - ロボット設定
+- [`So101PairSys`](../api/robots.md) - Leader-Followerペアシステム
+- [`EEPose`](../api/kinematics.md) - エンドエフェクタ姿勢
+- [`IKSolver`](../api/kinematics.md) - 逆運動学ソルバー
+- [`KinematicChain`](../api/kinematics.md) - キネマティックチェーン

--- a/docs/robots/so101.md
+++ b/docs/robots/so101.md
@@ -34,14 +34,14 @@ from robopy.config.robot_config.so101_config import So101Config
 # 基本設定（Followerのみ、Leaderなし）
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 
 # Leader付き設定（テレオペレーション用）
 config = So101Config(
     leader_port="/dev/ttyACM0",
     follower_port="/dev/ttyACM1",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 ```
 
@@ -53,7 +53,7 @@ from robopy.config.sensor_config.visual_config.camera_config import WebCameraCon
 
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
     sensors=So101SensorConfig(
         cameras={
             "top": WebCameraConfig(fps=30, width=640, height=480),
@@ -61,6 +61,68 @@ config = So101Config(
     ),
 )
 ```
+
+## :material-tune: キャリブレーション
+
+`robot.connect()` 時にキャリブレーションファイルが存在しない場合、対話的なキャリブレーションが自動実行されます。キャリブレーション方式は [lerobot](https://github.com/huggingface/lerobot) の最新版と同一です。
+
+### キャリブレーション手順
+
+キャリブレーションは各アーム（Leader / Follower）ごとに2ステップで行います。
+
+**ステップ 1: 可動域の中央位置を設定**
+
+各関節を可動域のおよそ中央に移動し、Enter を押します。各モーターのホーミングオフセット（`homing_offset = 現在位置 - 2047`）が計算され、モーターの EEPROM に書き込まれます。
+
+**ステップ 2: 可動域の記録**
+
+`wrist_roll` 以外の各関節を端から端までゆっくり動かし、Enter を押します。各関節の最小値（`range_min`）・最大値（`range_max`）がリアルタイムで記録されます。`wrist_roll` は全回転関節として `[0, 4095]` が自動設定されます。
+
+### キャリブレーションファイル
+
+キャリブレーションデータは JSON 形式で保存されます。
+
+```json
+{
+    "leader": {
+        "shoulder_pan": {
+            "id": 1,
+            "drive_mode": 0,
+            "homing_offset": -150,
+            "range_min": 1024,
+            "range_max": 3072
+        },
+        "gripper": {
+            "id": 6,
+            "drive_mode": 0,
+            "homing_offset": -80,
+            "range_min": 1500,
+            "range_max": 2600
+        }
+    },
+    "follower": { ... }
+}
+```
+
+| フィールド | 説明 |
+|-----------|------|
+| `id` | モーター ID（1〜6） |
+| `drive_mode` | 駆動方向（0 = 通常） |
+| `homing_offset` | ホーミングオフセット（中央位置の補正値） |
+| `range_min` | 可動域の最小エンコーダ値 |
+| `range_max` | 可動域の最大エンコーダ値 |
+
+### 位置の正規化
+
+キャリブレーションデータに基づき、生のエンコーダ値がユーザー向けの値に変換されます。
+
+- **DEGREES モード**（shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll）:
+    - `(raw - mid) * 360 / 4095`（`mid = (range_min + range_max) / 2`）
+- **RANGE_0_100 モード**（gripper）:
+    - `[range_min, range_max]` → `[0, 100]` への線形マッピング
+
+!!! tip "再キャリブレーション"
+    キャリブレーションをやり直すには、`calibration_path` で指定した JSON ファイルを削除してから `robot.connect()` を呼び出してください。
 
 ### ロボットの操作
 
@@ -70,7 +132,7 @@ from robopy.robots.so101.so101_robot import So101Robot
 robot = So101Robot(config)
 
 try:
-    # 接続（初回はキャリブレーションが実行されます）
+    # 接続（初回はキャリブレーションが自動実行されます）
     robot.connect()
 
     # テレオペレーション（10秒間）
@@ -311,7 +373,7 @@ from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
 # Followerのみの設定（Leaderアーム不要）
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
 )
 
 robot = So101Robot(cfg=config)
@@ -384,7 +446,7 @@ from robopy.config.robot_config.so101_config import So101Config, So101SensorConf
 # カメラ付き設定
 config = So101Config(
     follower_port="/dev/ttyACM0",
-    calibration_path="calibration/so101_calib.pkl",
+    calibration_path="calibration/so101_calib.json",
     sensors=So101SensorConfig(
         cameras={
             "top": WebCameraConfig(fps=30, width=640, height=480),

--- a/docs/robots/so101.md
+++ b/docs/robots/so101.md
@@ -233,28 +233,33 @@ T = chain.forward_kinematics_matrix(q)
 
 ### SO-101 のキネマティックパラメータ
 
-SO-101の物理パラメータは[SO-ARM100のURDF](https://github.com/TheRobotStudio/SO-ARM100)から取得しています。
+SO-101の物理パラメータは[SO-ARM100のURDF](https://github.com/TheRobotStudio/SO-ARM100)（`so101_new_calib.urdf`）から取得しています。
+
+URDFではすべての関節が**ローカルZ軸まわりの回転**（`axis xyz="0 0 1"`）として定義されています。各関節のオリジンに含まれるRPY回転がフレームの向きを決定し、ローカルZ軸が正しい物理方向を向くようになっています。
 
 ```mermaid
 graph LR
-    A[Base] -->|"(0.039, 0, 0.062) m"| B[Shoulder Pan<br/>Y軸回転]
-    B -->|"(-0.030, -0.018, -0.054) m"| C[Shoulder Lift<br/>X軸回転]
-    C -->|"(-0.113, -0.028, 0) m"| D[Elbow Flex<br/>X軸回転]
-    D -->|"(-0.135, 0.005, 0) m"| E[Wrist Flex<br/>X軸回転]
-    E -->|"(0, -0.061, 0.018) m"| F[Wrist Roll<br/>Y軸回転]
-    F -->|"(-0.008, 0, -0.098) m"| G[EE Frame]
+    A[Base] -->|"xyz=(0.039, 0, 0.062)<br/>rpy=(π, 0, -π)"| B[Shoulder Pan<br/>Z軸回転]
+    B -->|"xyz=(-0.030, -0.018, -0.054)<br/>rpy=(-π/2, -π/2, 0)"| C[Shoulder Lift<br/>Z軸回転]
+    C -->|"xyz=(-0.113, -0.028, 0)<br/>rpy=(0, 0, π/2)"| D[Elbow Flex<br/>Z軸回転]
+    D -->|"xyz=(-0.135, 0.005, 0)<br/>rpy=(0, 0, -π/2)"| E[Wrist Flex<br/>Z軸回転]
+    E -->|"xyz=(0, -0.061, 0.018)<br/>rpy=(π/2, 0.049, π)"| F[Wrist Roll<br/>Z軸回転]
+    F -->|"xyz=(-0.008, 0, -0.098)<br/>rpy=(0, π, 0)"| G[EE Frame]
 ```
 
-| 関節 | オフセット (m) | 回転軸 | 可動範囲 |
-|------|---------------|--------|---------|
-| shoulder_pan | (0.039, 0, 0.062) | Y | -110° ~ +110° |
-| shoulder_lift | (-0.030, -0.018, -0.054) | X | -100° ~ +100° |
-| elbow_flex | (-0.113, -0.028, 0) | X | -96.8° ~ +96.8° |
-| wrist_flex | (-0.135, 0.005, 0) | X | -95° ~ +95° |
-| wrist_roll | (0, -0.061, 0.018) | Y | -157.2° ~ +162.8° |
+| 関節 | オフセット xyz (m) | オリジン RPY (rad) | 回転軸 | 可動範囲 |
+|------|-------------------|-------------------|--------|---------|
+| shoulder_pan | (0.039, 0, 0.062) | (π, 0, -π) | Z | -110° ~ +110° |
+| shoulder_lift | (-0.030, -0.018, -0.054) | (-π/2, -π/2, 0) | Z | -100° ~ +100° |
+| elbow_flex | (-0.113, -0.028, 0) | (0, 0, π/2) | Z | -96.8° ~ +96.8° |
+| wrist_flex | (-0.135, 0.005, 0) | (0, 0, -π/2) | Z | -95° ~ +95° |
+| wrist_roll | (0, -0.061, 0.018) | (π/2, 0.049, π) | Z | -157.2° ~ +162.8° |
 
 !!! note "5自由度の制約"
     SO-101はgripperを除くと5自由度です。エンドエフェクタの位置（x, y, z）と姿勢のうち2成分（pitch, roll）を制御できますが、yaw（ヨー）は独立に制御できません。
+
+!!! info "URDF変換の計算"
+    各関節のFK変換は `T = Translation(xyz) @ Rz(yaw) @ Ry(pitch) @ Rx(roll) @ Rz(θ)` で計算されます。ここで θ は関節角度です。
 
 ## :material-gamepad-variant: SpaceMouse による制御 {#spacemouse}
 

--- a/examples/debug_spacemouse.py
+++ b/examples/debug_spacemouse.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Debug script to diagnose SpaceMouse connection issues.
+
+This script helps identify why SpaceMouse input might not be accessible.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def check_pyspacemouse_installed() -> bool:
+    """Check if pyspacemouse is installed."""
+    try:
+        import pyspacemouse
+
+        print("✓ pyspacemouse is installed")
+        print(f"  Version info: {pyspacemouse.__file__}")
+        return True
+    except ImportError:
+        print("✗ pyspacemouse is NOT installed")
+        print("  Install with: pip install pyspacemouse")
+        return False
+
+
+def check_device_list() -> None:
+    """List available HID devices."""
+    try:
+        import hid
+
+        print("\n✓ hid library is available")
+        print("\nListing HID devices (looking for 3Dconnexion devices):")
+        print("-" * 80)
+
+        devices = hid.enumerate()
+        spacemouse_found = False
+
+        for device in devices:
+            vendor_id = device.get("vendor_id", 0)
+            product_id = device.get("product_id", 0)
+            manufacturer = device.get("manufacturer_string", "")
+            product = device.get("product_string", "")
+
+            # 3Dconnexion vendor ID is 0x046d (Logitech) or 0x256f
+            if vendor_id in [0x046D, 0x256F] or "3Dconnexion" in manufacturer:
+                spacemouse_found = True
+                print(f"\n*** SPACEMOUSE DEVICE FOUND ***")
+                print(f"  Vendor ID:     0x{vendor_id:04X}")
+                print(f"  Product ID:    0x{product_id:04X}")
+                print(f"  Manufacturer:  {manufacturer}")
+                print(f"  Product:       {product}")
+                print(f"  Path:          {device.get('path', b'').decode('utf-8', errors='ignore')}")
+                print(f"  Usage Page:    {device.get('usage_page', 'N/A')}")
+                print(f"  Usage:         {device.get('usage', 'N/A')}")
+
+        if not spacemouse_found:
+            print("\n⚠ No 3Dconnexion/SpaceMouse devices found in HID enumeration")
+
+    except ImportError:
+        print("\n✗ hid library is NOT installed")
+        print("  Install with: pip install hidapi")
+
+
+def check_pyspacemouse_open() -> None:
+    """Try to open SpaceMouse with pyspacemouse."""
+    try:
+        import pyspacemouse
+
+        print("\n" + "=" * 80)
+        print("Attempting to open SpaceMouse with pyspacemouse...")
+        print("=" * 80)
+
+        # List supported devices
+        if hasattr(pyspacemouse, "list_devices"):
+            print("\nSupported devices:")
+            devices = pyspacemouse.list_devices()
+            for dev in devices:
+                print(f"  - {dev}")
+
+        device = pyspacemouse.open()
+
+        print("\n✓ Successfully opened SpaceMouse!")
+        print("\nTrying to read a few samples...")
+
+        for i in range(5):
+            state = device.read()
+            print(
+                f"  Sample {i+1}: "
+                f"x={state.x:.3f}, y={state.y:.3f}, z={state.z:.3f}, "
+                f"roll={state.roll:.3f}, pitch={state.pitch:.3f}, yaw={state.yaw:.3f}"
+            )
+
+        device.close()
+        print("\n✓ Read successful! SpaceMouse is working.")
+
+    except Exception as e:
+        print(f"\n✗ Error while trying to open SpaceMouse: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+def check_running_processes() -> None:
+    """Check if 3Dconnexion processes are running."""
+    import subprocess
+
+    print("\n" + "=" * 80)
+    print("Checking for 3Dconnexion processes...")
+    print("=" * 80)
+
+    try:
+        result = subprocess.run(
+            ["ps", "aux"],
+            capture_output=True,
+            text=True,
+        )
+
+        lines = [line for line in result.stdout.split("\n") if "3dconnexion" in line.lower()]
+
+        if lines:
+            print("\n⚠ Found 3Dconnexion processes running:")
+            for line in lines:
+                print(f"  {line}")
+            print("\nThese processes may be intercepting SpaceMouse input.")
+            print("To stop them, run:")
+            print("  killall 3DconnexionHelper")
+            print("  sudo killall 3Dconnexiond")
+        else:
+            print("\n✓ No 3Dconnexion processes found running")
+
+    except Exception as e:
+        print(f"\n✗ Error checking processes: {e}")
+
+
+def main() -> None:
+    """Run all diagnostic checks."""
+    print("SpaceMouse Debug Script")
+    print("=" * 80)
+
+    # Check 1: pyspacemouse installation
+    if not check_pyspacemouse_installed():
+        return
+
+    # Check 2: HID devices
+    check_device_list()
+
+    # Check 3: Running processes
+    check_running_processes()
+
+    # Check 4: Try to open
+    check_pyspacemouse_open()
+
+    print("\n" + "=" * 80)
+    print("Debug complete!")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/debug_spacemouse.py
+++ b/examples/debug_spacemouse.py
@@ -6,8 +6,6 @@ This script helps identify why SpaceMouse input might not be accessible.
 
 from __future__ import annotations
 
-import sys
-
 
 def check_pyspacemouse_installed() -> bool:
     """Check if pyspacemouse is installed."""
@@ -44,12 +42,13 @@ def check_device_list() -> None:
             # 3Dconnexion vendor ID is 0x046d (Logitech) or 0x256f
             if vendor_id in [0x046D, 0x256F] or "3Dconnexion" in manufacturer:
                 spacemouse_found = True
-                print(f"\n*** SPACEMOUSE DEVICE FOUND ***")
+                print("\n*** SPACEMOUSE DEVICE FOUND ***")
                 print(f"  Vendor ID:     0x{vendor_id:04X}")
                 print(f"  Product ID:    0x{product_id:04X}")
                 print(f"  Manufacturer:  {manufacturer}")
                 print(f"  Product:       {product}")
-                print(f"  Path:          {device.get('path', b'').decode('utf-8', errors='ignore')}")
+                path = device.get("path", b"").decode("utf-8", errors="ignore")
+                print(f"  Path:          {path}")
                 print(f"  Usage Page:    {device.get('usage_page', 'N/A')}")
                 print(f"  Usage:         {device.get('usage', 'N/A')}")
 
@@ -85,7 +84,7 @@ def check_pyspacemouse_open() -> None:
         for i in range(5):
             state = device.read()
             print(
-                f"  Sample {i+1}: "
+                f"  Sample {i + 1}: "
                 f"x={state.x:.3f}, y={state.y:.3f}, z={state.z:.3f}, "
                 f"roll={state.roll:.3f}, pitch={state.pitch:.3f}, yaw={state.yaw:.3f}"
             )

--- a/examples/demo_spacemouse.py
+++ b/examples/demo_spacemouse.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Demo script to test SpaceMouse input.
+
+This script continuously reads and displays SpaceMouse state until interrupted.
+Press Ctrl+C to stop.
+
+Usage:
+    python examples/demo_spacemouse.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+try:
+    from robopy.input.spacemouse import SpaceMouseReader
+except ImportError:
+    print("Error: Could not import SpaceMouseReader.")
+    print("Make sure robopy is installed: pip install -e .")
+    sys.exit(1)
+
+
+def main() -> None:
+    """Run the SpaceMouse demo."""
+    print("SpaceMouse Demo")
+    print("=" * 60)
+    print("Starting SpaceMouse reader...")
+    print("Move the SpaceMouse to see values.")
+    print("Press Ctrl+C to stop.\n")
+
+    reader = SpaceMouseReader()
+
+    try:
+        # Start the reader
+        reader.start()
+        print("SpaceMouse reader started successfully!\n")
+
+        # Continuously read and display state
+        while True:
+            state = reader.get_state()
+
+            # Clear line and print state
+            print(
+                f"\r"
+                f"X: {state.x:+.3f} | "
+                f"Y: {state.y:+.3f} | "
+                f"Z: {state.z:+.3f} | "
+                f"Roll: {state.roll:+.3f} | "
+                f"Pitch: {state.pitch:+.3f} | "
+                f"Yaw: {state.yaw:+.3f} | "
+                f"Buttons: {state.buttons} | "
+                f"Time: {state.timestamp:.3f}",
+                end="",
+                flush=True,
+            )
+
+            time.sleep(0.05)  # 20 Hz update rate
+
+    except KeyboardInterrupt:
+        print("\n\nStopping SpaceMouse reader...")
+
+    except Exception as e:
+        print(f"\n\nError: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+    finally:
+        # Clean up
+        reader.stop()
+        print("SpaceMouse reader stopped.")
+        print("Demo finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
     - Data handling: utils/data-handling.md
   - API Reference:
     - Robot: api/robots.md
+    - SpaceMouse: api/spacemouse.md
     - Kinematics: api/kinematics.md
     - Sensor: api/sensors.md
     - Setting: api/config.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
   - Robot:
     - Rakuda: robots/rakuda.md
     - Koch: robots/koch.md
+    - SO-101: robots/so101.md
   - Sensor:
     - Cameras: sensors/cameras.md
     - Tactile: sensors/tactile.md
@@ -142,6 +143,7 @@ nav:
     - Data handling: utils/data-handling.md
   - API Reference:
     - Robot: api/robots.md
+    - Kinematics: api/kinematics.md
     - Sensor: api/sensors.md
     - Setting: api/config.md
     - Utils: api/utils.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "robopy"
 version = "0.3.2"
-description = "A Python library for controlling robots with Dynamixel actuators and Intel RealSense cameras."
+description = "A Python library for controlling robots with Dynamixel and Feetech actuators and Intel RealSense cameras."
 readme = "README.md"
 authors = [{ name = "tetsugo", email = "tetsugou2002@gmail.com" }]
 requires-python = ">=3.11"
@@ -19,6 +19,7 @@ dependencies = [
     "pyaudio>=0.2.14",
     "pyyaml>=6.0.2",
     "rich>=14.1.0",
+    "feetech-servo-sdk>=1.0.0",
     "tqdm>=4.67.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ docs = [
     "mkdocstrings[python]>=0.24.0",
     "mkdocs-git-revision-date-localized-plugin>=1.2.0",
 ]
+spacemouse = ["pyspacemouse>=0.0.7"]
 linux = ["pyrealsense2>=2.54.2"]                         # Linux専用依存
 
 [build-system]

--- a/src/robopy/config/__init__.py
+++ b/src/robopy/config/__init__.py
@@ -1,3 +1,4 @@
+from .input_config.spacemouse_config import SpaceMouseConfig
 from .robot_config.koch_config import (
     KochConfig,
     KochObservation,
@@ -20,6 +21,7 @@ from .sensor_config.visual_config.camera_config import (
 )
 
 __all__ = [
+    "SpaceMouseConfig",
     "RakudaConfig",
     "RakudaArmObs",
     "RakudaObs",

--- a/src/robopy/config/input_config/__init__.py
+++ b/src/robopy/config/input_config/__init__.py
@@ -1,0 +1,5 @@
+"""Input device configuration."""
+
+from .spacemouse_config import SpaceMouseConfig
+
+__all__ = ["SpaceMouseConfig"]

--- a/src/robopy/config/input_config/spacemouse_config.py
+++ b/src/robopy/config/input_config/spacemouse_config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SpaceMouseConfig:
+    """Configuration for SpaceMouse input device.
+
+    Attributes:
+        linear_speed: Maximum linear velocity in m/s when the SpaceMouse axis
+            is at full deflection (1.0).
+        angular_speed: Maximum angular velocity in rad/s when the SpaceMouse
+            axis is at full deflection (1.0).
+        gripper_speed: Gripper movement speed in degrees/s per button press.
+        deadzone: Axes with absolute values below this threshold are zeroed.
+        control_hz: Control loop frequency in Hz.
+    """
+
+    linear_speed: float = 0.10
+    angular_speed: float = 0.5
+    gripper_speed: float = 50.0
+    deadzone: float = 0.05
+    control_hz: int = 50

--- a/src/robopy/config/input_config/spacemouse_config.py
+++ b/src/robopy/config/input_config/spacemouse_config.py
@@ -13,6 +13,11 @@ class SpaceMouseConfig:
         gripper_speed: Gripper movement speed in degrees/s per button press.
         deadzone: Axes with absolute values below this threshold are zeroed.
         control_hz: Control loop frequency in Hz.
+        input_smoothing: Exponential moving average factor for SpaceMouse axes.
+            0.0 = no smoothing (raw input), 1.0 = maximum smoothing.
+            Higher values reduce jitter but add latency.
+        max_joint_delta_deg: Maximum allowed joint angle change per control
+            step in degrees.  Prevents vibration from large IK solution jumps.
     """
 
     linear_speed: float = 0.10
@@ -20,3 +25,5 @@ class SpaceMouseConfig:
     gripper_speed: float = 50.0
     deadzone: float = 0.05
     control_hz: int = 50
+    input_smoothing: float = 0.5
+    max_joint_delta_deg: float = 5.0

--- a/src/robopy/config/robot_config/__init__.py
+++ b/src/robopy/config/robot_config/__init__.py
@@ -8,6 +8,7 @@ from .rakuda_config import (
     RakudaObs,
     RakudaSensorParams,
 )
+from .so101_config import SO101_MOTOR_MAPPING, So101Config
 
 __all__ = [
     "RakudaConfig",
@@ -16,4 +17,6 @@ __all__ = [
     "KochConfig",
     "RAKUDA_CONTROLTABLE_VALUES",
     "RAKUDA_MOTOR_MAPPING",
+    "So101Config",
+    "SO101_MOTOR_MAPPING",
 ]

--- a/src/robopy/config/robot_config/so101_config.py
+++ b/src/robopy/config/robot_config/so101_config.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, field
+from typing import Dict
+
+from robopy.config.sensor_config.visual_config.camera_config import (
+    RealsenseCameraConfig,
+    WebCameraConfig,
+)
+
+
+@dataclass
+class So101SensorConfig:
+    """Sensor configuration for SO-101 robot."""
+
+    cameras: Dict[str, RealsenseCameraConfig | WebCameraConfig] = field(default_factory=dict)
+
+
+@dataclass
+class So101Config:
+    """Configuration class for SO-101 robot.
+
+    The SO-101 uses Feetech STS3215 motors with 6 joints per arm:
+    shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll, gripper.
+    """
+
+    follower_port: str
+    calibration_path: str
+    leader_port: str | None = None
+    sensors: So101SensorConfig = field(default_factory=So101SensorConfig)
+
+
+SO101_MOTOR_MAPPING: Dict[str, str] = {
+    "shoulder_pan": "shoulder_pan",
+    "shoulder_lift": "shoulder_lift",
+    "elbow_flex": "elbow_flex",
+    "wrist_flex": "wrist_flex",
+    "wrist_roll": "wrist_roll",
+    "gripper": "gripper",
+}

--- a/src/robopy/input/__init__.py
+++ b/src/robopy/input/__init__.py
@@ -1,0 +1,5 @@
+"""Input device modules."""
+
+from .spacemouse import SpaceMouseReader, SpaceMouseState
+
+__all__ = ["SpaceMouseReader", "SpaceMouseState"]

--- a/src/robopy/input/spacemouse.py
+++ b/src/robopy/input/spacemouse.py
@@ -1,0 +1,146 @@
+"""Thread-safe SpaceMouse reader using the pyspacemouse library."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SpaceMouseState:
+    """Snapshot of the SpaceMouse 6-DOF axes and button states.
+
+    All axis values are normalised to ``[-1.0, 1.0]``.
+    """
+
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+    roll: float = 0.0
+    pitch: float = 0.0
+    yaw: float = 0.0
+    buttons: list[bool] = field(default_factory=lambda: [False, False])
+    timestamp: float = 0.0
+
+
+class SpaceMouseReader:
+    """Thread-based wrapper around *pyspacemouse*.
+
+    A background daemon thread polls ``pyspacemouse.read()`` at high frequency
+    and stores the latest state behind a lock so that callers can retrieve it
+    without blocking.
+
+    Usage::
+
+        reader = SpaceMouseReader()
+        reader.start()
+        state = reader.get_state()
+        reader.stop()
+    """
+
+    _POLL_INTERVAL: float = 1.0 / 200.0  # ~200 Hz
+
+    def __init__(self) -> None:
+        self._state = SpaceMouseState()
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._is_running = False
+
+    @property
+    def is_running(self) -> bool:
+        return self._is_running
+
+    def start(self) -> None:
+        """Open the SpaceMouse device and start the polling thread."""
+        if self._is_running:
+            logger.warning("SpaceMouseReader is already running.")
+            return
+
+        try:
+            import pyspacemouse
+        except ImportError as exc:
+            raise ImportError(
+                "pyspacemouse is required for SpaceMouse support. "
+                "Install it with: pip install pyspacemouse"
+            ) from exc
+
+        success = pyspacemouse.open()
+        if not success:
+            raise RuntimeError(
+                "Failed to open SpaceMouse device. "
+                "Check that the device is connected and permissions are set."
+            )
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+        self._is_running = True
+        logger.info("SpaceMouseReader started.")
+
+    def stop(self) -> None:
+        """Stop the polling thread and close the device."""
+        if not self._is_running:
+            return
+
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+        try:
+            import pyspacemouse
+
+            pyspacemouse.close()
+        except Exception:
+            pass
+
+        self._is_running = False
+        logger.info("SpaceMouseReader stopped.")
+
+    def get_state(self) -> SpaceMouseState:
+        """Return the latest SpaceMouse state (non-blocking)."""
+        with self._lock:
+            return SpaceMouseState(
+                x=self._state.x,
+                y=self._state.y,
+                z=self._state.z,
+                roll=self._state.roll,
+                pitch=self._state.pitch,
+                yaw=self._state.yaw,
+                buttons=list(self._state.buttons),
+                timestamp=self._state.timestamp,
+            )
+
+    def _poll_loop(self) -> None:
+        """Background polling loop."""
+        import pyspacemouse
+
+        while not self._stop_event.is_set():
+            try:
+                raw = pyspacemouse.read()
+
+                buttons = [False, False]
+                if hasattr(raw, "buttons") and raw.buttons:
+                    for i, val in enumerate(raw.buttons):
+                        if i < 2:
+                            buttons[i] = bool(val)
+
+                with self._lock:
+                    self._state.x = float(raw.x)
+                    self._state.y = float(raw.y)
+                    self._state.z = float(raw.z)
+                    self._state.roll = float(raw.roll)
+                    self._state.pitch = float(raw.pitch)
+                    self._state.yaw = float(raw.yaw)
+                    self._state.buttons = buttons
+                    self._state.timestamp = time.time()
+
+            except Exception as exc:
+                logger.debug("SpaceMouse read error: %s", exc)
+
+            time.sleep(self._POLL_INTERVAL)

--- a/src/robopy/kinematics/__init__.py
+++ b/src/robopy/kinematics/__init__.py
@@ -1,0 +1,17 @@
+"""Kinematics module for robopy: FK and IK for 5-DOF robot arms."""
+
+from .chain import KinematicChain, RevoluteJoint
+from .ee_pose import EEPose
+from .ik_solver import IKConfig, IKResult, IKSolver
+from .robot_chains import koch_chain, so101_chain
+
+__all__ = [
+    "EEPose",
+    "IKConfig",
+    "IKResult",
+    "IKSolver",
+    "KinematicChain",
+    "RevoluteJoint",
+    "koch_chain",
+    "so101_chain",
+]

--- a/src/robopy/kinematics/chain.py
+++ b/src/robopy/kinematics/chain.py
@@ -79,9 +79,7 @@ class KinematicChain:
             4x4 homogeneous transformation matrix.
         """
         if len(joint_angles_rad) != self._n_joints:
-            raise ValueError(
-                f"Expected {self._n_joints} joint angles, got {len(joint_angles_rad)}"
-            )
+            raise ValueError(f"Expected {self._n_joints} joint angles, got {len(joint_angles_rad)}")
 
         T = np.eye(4)
         for i, joint in enumerate(self._joints):
@@ -90,9 +88,7 @@ class KinematicChain:
         T = T @ self._ee_fixed
         return T
 
-    def forward_kinematics(
-        self, joint_angles_rad: NDArray[np.float64]
-    ) -> NDArray[np.float64]:
+    def forward_kinematics(self, joint_angles_rad: NDArray[np.float64]) -> NDArray[np.float64]:
         """Compute end-effector pose as (x, y, z, pitch, roll).
 
         Args:
@@ -134,8 +130,6 @@ class KinematicChain:
 
         return J
 
-    def clamp_to_limits(
-        self, joint_angles_rad: NDArray[np.float64]
-    ) -> NDArray[np.float64]:
+    def clamp_to_limits(self, joint_angles_rad: NDArray[np.float64]) -> NDArray[np.float64]:
         """Clamp joint angles to their limits."""
         return np.clip(joint_angles_rad, self.lower_limits_rad, self.upper_limits_rad)

--- a/src/robopy/kinematics/chain.py
+++ b/src/robopy/kinematics/chain.py
@@ -1,0 +1,141 @@
+"""Kinematic chain with forward kinematics and numerical Jacobian."""
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .transforms import pose_from_matrix, rot_x, rot_y, rot_z
+
+_ROT_FUNCS = {"x": rot_x, "y": rot_y, "z": rot_z}
+
+
+@dataclass(frozen=True)
+class RevoluteJoint:
+    """A single revolute joint in the kinematic chain.
+
+    Attributes:
+        name: Joint name (e.g., "shoulder_pan").
+        parent_to_joint: 4x4 static transform from parent frame to this joint's
+            rotation center (before any rotation is applied).
+        axis: Rotation axis as a string: "x", "y", or "z".
+        lower_limit_rad: Minimum joint angle in radians.
+        upper_limit_rad: Maximum joint angle in radians.
+    """
+
+    name: str
+    parent_to_joint: NDArray[np.float64]
+    axis: str
+    lower_limit_rad: float
+    upper_limit_rad: float
+
+    def __post_init__(self) -> None:
+        if self.axis not in _ROT_FUNCS:
+            raise ValueError(f"axis must be 'x', 'y', or 'z', got '{self.axis}'")
+
+
+class KinematicChain:
+    """Forward kinematics and numerical Jacobian for a serial revolute chain.
+
+    The chain is a sequence of :class:`RevoluteJoint` objects followed by a
+    fixed transform from the last joint frame to the end-effector frame.
+    """
+
+    def __init__(
+        self,
+        joints: List[RevoluteJoint],
+        ee_fixed_transform: NDArray[np.float64],
+    ) -> None:
+        self._joints = list(joints)
+        self._ee_fixed = np.array(ee_fixed_transform, dtype=np.float64)
+        self._n_joints = len(self._joints)
+
+    @property
+    def n_joints(self) -> int:
+        return self._n_joints
+
+    @property
+    def joint_names(self) -> List[str]:
+        return [j.name for j in self._joints]
+
+    @property
+    def lower_limits_rad(self) -> NDArray[np.float64]:
+        return np.array([j.lower_limit_rad for j in self._joints])
+
+    @property
+    def upper_limits_rad(self) -> NDArray[np.float64]:
+        return np.array([j.upper_limit_rad for j in self._joints])
+
+    def forward_kinematics_matrix(
+        self, joint_angles_rad: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Compute the 4x4 homogeneous transform from base to end-effector.
+
+        Args:
+            joint_angles_rad: (n_joints,) array of joint angles in radians.
+
+        Returns:
+            4x4 homogeneous transformation matrix.
+        """
+        if len(joint_angles_rad) != self._n_joints:
+            raise ValueError(
+                f"Expected {self._n_joints} joint angles, got {len(joint_angles_rad)}"
+            )
+
+        T = np.eye(4)
+        for i, joint in enumerate(self._joints):
+            rot_fn = _ROT_FUNCS[joint.axis]
+            T = T @ joint.parent_to_joint @ rot_fn(float(joint_angles_rad[i]))
+        T = T @ self._ee_fixed
+        return T
+
+    def forward_kinematics(
+        self, joint_angles_rad: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Compute end-effector pose as (x, y, z, pitch, roll).
+
+        Args:
+            joint_angles_rad: (n_joints,) array of joint angles in radians.
+
+        Returns:
+            (5,) array [x, y, z, pitch, roll].
+        """
+        T = self.forward_kinematics_matrix(joint_angles_rad)
+        return pose_from_matrix(T)
+
+    def jacobian(
+        self, joint_angles_rad: NDArray[np.float64], delta: float = 1e-6
+    ) -> NDArray[np.float64]:
+        """Numerical Jacobian of the 5-DOF pose w.r.t. joint angles.
+
+        Uses central finite differences for O(delta^2) accuracy.
+
+        Returns:
+            (5, n_joints) Jacobian matrix.
+        """
+        J = np.zeros((5, self._n_joints))
+
+        for i in range(self._n_joints):
+            q_plus = joint_angles_rad.copy()
+            q_minus = joint_angles_rad.copy()
+            q_plus[i] += delta
+            q_minus[i] -= delta
+
+            pose_plus = self.forward_kinematics(q_plus)
+            pose_minus = self.forward_kinematics(q_minus)
+
+            diff = pose_plus - pose_minus
+            # Wrap angular components to [-pi, pi]
+            for k in (3, 4):
+                diff[k] = (diff[k] + np.pi) % (2 * np.pi) - np.pi
+
+            J[:, i] = diff / (2 * delta)
+
+        return J
+
+    def clamp_to_limits(
+        self, joint_angles_rad: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Clamp joint angles to their limits."""
+        return np.clip(joint_angles_rad, self.lower_limits_rad, self.upper_limits_rad)

--- a/src/robopy/kinematics/ee_pose.py
+++ b/src/robopy/kinematics/ee_pose.py
@@ -1,0 +1,42 @@
+"""End-effector pose representation for 5-DOF robots."""
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class EEPose:
+    """5-DOF end-effector pose.
+
+    Attributes:
+        x: End-effector X position in meters.
+        y: End-effector Y position in meters.
+        z: End-effector Z position in meters.
+        pitch: Rotation about the Y-axis in radians.
+        roll: Rotation about the X-axis in radians.
+    """
+
+    x: float
+    y: float
+    z: float
+    pitch: float
+    roll: float
+
+    def to_array(self) -> NDArray[np.float64]:
+        """Return (5,) numpy array [x, y, z, pitch, roll]."""
+        return np.array([self.x, self.y, self.z, self.pitch, self.roll])
+
+    @classmethod
+    def from_array(cls, arr: NDArray[np.float64]) -> "EEPose":
+        """Construct from a (5,) array."""
+        if len(arr) != 5:
+            raise ValueError(f"Expected 5 elements, got {len(arr)}")
+        return cls(
+            x=float(arr[0]),
+            y=float(arr[1]),
+            z=float(arr[2]),
+            pitch=float(arr[3]),
+            roll=float(arr[4]),
+        )

--- a/src/robopy/kinematics/ik_solver.py
+++ b/src/robopy/kinematics/ik_solver.py
@@ -67,9 +67,7 @@ class IKSolver:
     scipy required.
     """
 
-    def __init__(
-        self, chain: KinematicChain, config: IKConfig | None = None
-    ) -> None:
+    def __init__(self, chain: KinematicChain, config: IKConfig | None = None) -> None:
         self._chain = chain
         self._config = config or IKConfig()
 
@@ -94,13 +92,15 @@ class IKSolver:
         cfg = self._config
         q = initial_angles_rad.copy().astype(np.float64)
 
-        W = np.diag([
-            cfg.position_weight,
-            cfg.position_weight,
-            cfg.position_weight,
-            cfg.orientation_weight,
-            cfg.orientation_weight,
-        ])
+        W = np.diag(
+            [
+                cfg.position_weight,
+                cfg.position_weight,
+                cfg.position_weight,
+                cfg.orientation_weight,
+                cfg.orientation_weight,
+            ]
+        )
 
         lower = self._chain.lower_limits_rad + cfg.joint_limit_margin_rad
         upper = self._chain.upper_limits_rad - cfg.joint_limit_margin_rad

--- a/src/robopy/kinematics/ik_solver.py
+++ b/src/robopy/kinematics/ik_solver.py
@@ -145,7 +145,7 @@ class IKSolver:
         pos_err = float(np.linalg.norm(error[:3]))
         ori_err = float(np.linalg.norm(error[3:]))
 
-        logger.warning(
+        logger.debug(
             "IK did not converge after %d iterations. "
             "Position error: %.6f m, Orientation error: %.6f rad",
             cfg.max_iterations,

--- a/src/robopy/kinematics/ik_solver.py
+++ b/src/robopy/kinematics/ik_solver.py
@@ -1,0 +1,162 @@
+"""Damped least-squares inverse kinematics solver (numpy only)."""
+
+from dataclasses import dataclass
+from logging import getLogger
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .chain import KinematicChain
+
+logger = getLogger(__name__)
+
+
+@dataclass
+class IKConfig:
+    """Configuration for the IK solver.
+
+    Attributes:
+        max_iterations: Maximum solver iterations.
+        position_tolerance: Convergence threshold for position error (meters).
+        orientation_tolerance: Convergence threshold for orientation error (radians).
+        damping: Damping factor lambda for DLS. Higher = more stable, less accurate.
+        step_scale: Scale factor for each iteration step (0 < step_scale <= 1).
+        position_weight: Weight for position (x, y, z) components in the error.
+        orientation_weight: Weight for orientation (pitch, roll) components.
+        joint_limit_margin_rad: Stay this far inside joint limits.
+    """
+
+    max_iterations: int = 100
+    position_tolerance: float = 1e-4  # 0.1 mm
+    orientation_tolerance: float = 1e-3  # ~0.06 degrees
+    damping: float = 0.05
+    step_scale: float = 0.5
+    position_weight: float = 1.0
+    orientation_weight: float = 0.1
+    joint_limit_margin_rad: float = 0.01  # ~0.57 degrees
+
+
+@dataclass
+class IKResult:
+    """Result from the IK solver.
+
+    Attributes:
+        joint_angles_rad: (n_joints,) solution joint angles in radians.
+        success: Whether the solver converged within tolerance.
+        iterations: Number of iterations used.
+        position_error: Final Euclidean position error in meters.
+        orientation_error: Final orientation error in radians.
+    """
+
+    joint_angles_rad: NDArray[np.float64]
+    success: bool
+    iterations: int
+    position_error: float
+    orientation_error: float
+
+
+class IKSolver:
+    """Damped Least-Squares (Levenberg-Marquardt style) IK solver.
+
+    Uses the formulation::
+
+        dq = J_w^T (J_w J_w^T + lambda^2 I)^{-1} e_w
+
+    where *J_w* is the weighted Jacobian and *e_w* is the weighted task-space
+    error.  The 5x5 linear system is solved with ``np.linalg.solve`` — no
+    scipy required.
+    """
+
+    def __init__(
+        self, chain: KinematicChain, config: IKConfig | None = None
+    ) -> None:
+        self._chain = chain
+        self._config = config or IKConfig()
+
+    @property
+    def config(self) -> IKConfig:
+        return self._config
+
+    def solve(
+        self,
+        target_pose: NDArray[np.float64],
+        initial_angles_rad: NDArray[np.float64],
+    ) -> IKResult:
+        """Solve IK for a target 5-DOF pose.
+
+        Args:
+            target_pose: (5,) array [x, y, z, pitch, roll].
+            initial_angles_rad: (n_joints,) initial guess in radians.
+
+        Returns:
+            IKResult with solution and convergence information.
+        """
+        cfg = self._config
+        q = initial_angles_rad.copy().astype(np.float64)
+
+        W = np.diag([
+            cfg.position_weight,
+            cfg.position_weight,
+            cfg.position_weight,
+            cfg.orientation_weight,
+            cfg.orientation_weight,
+        ])
+
+        lower = self._chain.lower_limits_rad + cfg.joint_limit_margin_rad
+        upper = self._chain.upper_limits_rad - cfg.joint_limit_margin_rad
+
+        for iteration in range(cfg.max_iterations):
+            current_pose = self._chain.forward_kinematics(q)
+            error = target_pose - current_pose
+
+            # Wrap angular errors to [-pi, pi]
+            for k in (3, 4):
+                error[k] = (error[k] + np.pi) % (2 * np.pi) - np.pi
+
+            pos_err = float(np.linalg.norm(error[:3]))
+            ori_err = float(np.linalg.norm(error[3:]))
+
+            if pos_err < cfg.position_tolerance and ori_err < cfg.orientation_tolerance:
+                return IKResult(
+                    joint_angles_rad=q,
+                    success=True,
+                    iterations=iteration + 1,
+                    position_error=pos_err,
+                    orientation_error=ori_err,
+                )
+
+            # Weighted error and Jacobian
+            e_w = W @ error
+            J = self._chain.jacobian(q)
+            J_w = W @ J  # (5, n_joints)
+
+            # DLS: dq = J_w^T (J_w J_w^T + lambda^2 I)^{-1} e_w
+            JJT = J_w @ J_w.T  # (5, 5)
+            damped = JJT + (cfg.damping**2) * np.eye(5)
+            y = np.linalg.solve(damped, e_w)
+            dq = J_w.T @ y
+
+            q = q + cfg.step_scale * dq
+            q = np.clip(q, lower, upper)
+
+        # Did not converge — compute final error
+        current_pose = self._chain.forward_kinematics(q)
+        error = target_pose - current_pose
+        pos_err = float(np.linalg.norm(error[:3]))
+        ori_err = float(np.linalg.norm(error[3:]))
+
+        logger.warning(
+            "IK did not converge after %d iterations. "
+            "Position error: %.6f m, Orientation error: %.6f rad",
+            cfg.max_iterations,
+            pos_err,
+            ori_err,
+        )
+
+        return IKResult(
+            joint_angles_rad=q,
+            success=False,
+            iterations=cfg.max_iterations,
+            position_error=pos_err,
+            orientation_error=ori_err,
+        )

--- a/src/robopy/kinematics/robot_chains.py
+++ b/src/robopy/kinematics/robot_chains.py
@@ -1,0 +1,127 @@
+"""Factory functions creating KinematicChain for each supported robot."""
+
+from .chain import KinematicChain, RevoluteJoint
+from .transforms import translation
+
+
+def so101_chain() -> KinematicChain:
+    """Create the kinematic chain for the SO-101 robot (5-DOF, excluding gripper).
+
+    Parameters are derived from the SO-101 URDF
+    (``SO-ARM100/Simulation/SO101/so101_new_calib.urdf``).
+
+    Joint axes follow the URDF convention:
+        shoulder_pan / wrist_roll → Y-axis rotation,
+        shoulder_lift / elbow_flex / wrist_flex → X-axis rotation.
+    """
+    joints = [
+        RevoluteJoint(
+            name="shoulder_pan",
+            parent_to_joint=translation(0.0388, 0.0, 0.0624),
+            axis="y",
+            lower_limit_rad=-1.91986,  # -110 deg
+            upper_limit_rad=1.91986,  # +110 deg
+        ),
+        RevoluteJoint(
+            name="shoulder_lift",
+            parent_to_joint=translation(-0.0304, -0.0183, -0.0542),
+            axis="x",
+            lower_limit_rad=-1.74533,  # -100 deg
+            upper_limit_rad=1.74533,  # +100 deg
+        ),
+        RevoluteJoint(
+            name="elbow_flex",
+            parent_to_joint=translation(-0.11257, -0.028, 0.0),
+            axis="x",
+            lower_limit_rad=-1.69,  # -96.8 deg
+            upper_limit_rad=1.69,  # +96.8 deg
+        ),
+        RevoluteJoint(
+            name="wrist_flex",
+            parent_to_joint=translation(-0.1349, 0.0052, 0.0),
+            axis="x",
+            lower_limit_rad=-1.65806,  # -95 deg
+            upper_limit_rad=1.65806,  # +95 deg
+        ),
+        RevoluteJoint(
+            name="wrist_roll",
+            parent_to_joint=translation(0.0, -0.0611, 0.0181),
+            axis="y",
+            lower_limit_rad=-2.74385,  # -157.2 deg
+            upper_limit_rad=2.84121,  # +162.8 deg
+        ),
+    ]
+
+    # Fixed transform from wrist_roll frame to end-effector tip
+    # (gripper_frame_joint offset from the URDF).
+    ee_fixed = translation(-0.0079, 0.0, -0.0981)
+
+    return KinematicChain(joints=joints, ee_fixed_transform=ee_fixed)
+
+
+def koch_chain() -> KinematicChain:
+    """Create the kinematic chain for the Koch v1.1 robot (5-DOF, excluding gripper).
+
+    .. warning::
+
+        Koch has **no official URDF**.  The parameters below are rough
+        approximations from MuJoCo menagerie and CAD drawings.  Every numeric
+        constant is marked with ``TODO(physical-params)`` and **must** be
+        validated against the physical robot before production use.
+
+    TODO(physical-params): Validate shoulder_pan offset against real robot.
+    TODO(physical-params): Measure exact upper_arm length (currently ~110 mm est.).
+    TODO(physical-params): Measure exact forearm length (currently ~100 mm est.).
+    TODO(physical-params): Validate wrist offset and EE frame position.
+    TODO(physical-params): Measure and confirm joint axis directions.
+    TODO(physical-params): Calibrate joint limit values against real hardware.
+    """
+    joints = [
+        RevoluteJoint(
+            name="shoulder_pan",
+            # TODO(physical-params): Approximate. Measure base-to-shoulder offset.
+            parent_to_joint=translation(0.0, 0.0, 0.05),
+            axis="y",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-2.61799,  # -150 deg (estimate)
+            upper_limit_rad=2.61799,  # +150 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="shoulder_lift",
+            # TODO(physical-params): Approximate shoulder-to-upper-arm offset.
+            parent_to_joint=translation(0.0, 0.0, -0.04),
+            axis="x",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-1.74533,  # -100 deg (estimate)
+            upper_limit_rad=1.74533,  # +100 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="elbow",
+            # Upper arm length ~110 mm
+            # TODO(physical-params): Measure precisely.
+            parent_to_joint=translation(-0.110, 0.0, 0.0),
+            axis="x",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-1.74533,  # -100 deg (estimate)
+            upper_limit_rad=1.74533,  # +100 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="wrist_flex",
+            # Forearm length ~100 mm
+            # TODO(physical-params): Measure precisely.
+            parent_to_joint=translation(-0.100, 0.0, 0.0),
+            axis="x",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-1.74533,  # -100 deg (estimate)
+            upper_limit_rad=1.74533,  # +100 deg (estimate)
+        ),
+        RevoluteJoint(
+            name="wrist_roll",
+            # TODO(physical-params): Approximate wrist-to-gripper offset.
+            parent_to_joint=translation(0.0, -0.04, 0.0),
+            axis="y",  # TODO(physical-params): Confirm axis direction
+            lower_limit_rad=-3.14159,  # -180 deg (estimate)
+            upper_limit_rad=3.14159,  # +180 deg (estimate)
+        ),
+    ]
+
+    # TODO(physical-params): Measure precise EE offset from wrist_roll.
+    ee_fixed = translation(0.0, 0.0, -0.06)
+
+    return KinematicChain(joints=joints, ee_fixed_transform=ee_fixed)

--- a/src/robopy/kinematics/transforms.py
+++ b/src/robopy/kinematics/transforms.py
@@ -7,34 +7,40 @@ from numpy.typing import NDArray
 def rot_x(theta: float) -> NDArray[np.float64]:
     """4x4 rotation matrix about X-axis. theta in radians."""
     c, s = np.cos(theta), np.sin(theta)
-    return np.array([
-        [1.0, 0.0, 0.0, 0.0],
-        [0.0, c, -s, 0.0],
-        [0.0, s, c, 0.0],
-        [0.0, 0.0, 0.0, 1.0],
-    ])
+    return np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, c, -s, 0.0],
+            [0.0, s, c, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
 
 
 def rot_y(theta: float) -> NDArray[np.float64]:
     """4x4 rotation matrix about Y-axis. theta in radians."""
     c, s = np.cos(theta), np.sin(theta)
-    return np.array([
-        [c, 0.0, s, 0.0],
-        [0.0, 1.0, 0.0, 0.0],
-        [-s, 0.0, c, 0.0],
-        [0.0, 0.0, 0.0, 1.0],
-    ])
+    return np.array(
+        [
+            [c, 0.0, s, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [-s, 0.0, c, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
 
 
 def rot_z(theta: float) -> NDArray[np.float64]:
     """4x4 rotation matrix about Z-axis. theta in radians."""
     c, s = np.cos(theta), np.sin(theta)
-    return np.array([
-        [c, -s, 0.0, 0.0],
-        [s, c, 0.0, 0.0],
-        [0.0, 0.0, 1.0, 0.0],
-        [0.0, 0.0, 0.0, 1.0],
-    ])
+    return np.array(
+        [
+            [c, -s, 0.0, 0.0],
+            [s, c, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
 
 
 def translation(x: float, y: float, z: float) -> NDArray[np.float64]:

--- a/src/robopy/kinematics/transforms.py
+++ b/src/robopy/kinematics/transforms.py
@@ -1,0 +1,62 @@
+"""Homogeneous transformation utilities using only numpy."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def rot_x(theta: float) -> NDArray[np.float64]:
+    """4x4 rotation matrix about X-axis. theta in radians."""
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, c, -s, 0.0],
+        [0.0, s, c, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ])
+
+
+def rot_y(theta: float) -> NDArray[np.float64]:
+    """4x4 rotation matrix about Y-axis. theta in radians."""
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([
+        [c, 0.0, s, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [-s, 0.0, c, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ])
+
+
+def rot_z(theta: float) -> NDArray[np.float64]:
+    """4x4 rotation matrix about Z-axis. theta in radians."""
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([
+        [c, -s, 0.0, 0.0],
+        [s, c, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ])
+
+
+def translation(x: float, y: float, z: float) -> NDArray[np.float64]:
+    """4x4 pure translation matrix."""
+    T = np.eye(4)
+    T[0, 3] = x
+    T[1, 3] = y
+    T[2, 3] = z
+    return T
+
+
+def pose_from_matrix(T: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Extract (x, y, z, pitch, roll) from a 4x4 homogeneous matrix.
+
+    Convention (Y-X intrinsic / extrinsic ZYX subset):
+        pitch = atan2(-R[2,0], sqrt(R[0,0]^2 + R[1,0]^2))  -- rotation about Y
+        roll  = atan2(R[2,1], R[2,2])                        -- rotation about X
+
+    Yaw is omitted because the 5-DOF arm cannot independently control it.
+    """
+    x, y_val, z = float(T[0, 3]), float(T[1, 3]), float(T[2, 3])
+    R = T[:3, :3]
+    pitch = float(np.arctan2(-R[2, 0], np.sqrt(R[0, 0] ** 2 + R[1, 0] ** 2)))
+    roll = float(np.arctan2(R[2, 1], R[2, 2]))
+    return np.array([x, y_val, z, pitch, roll])

--- a/src/robopy/kinematics/transforms.py
+++ b/src/robopy/kinematics/transforms.py
@@ -46,6 +46,19 @@ def translation(x: float, y: float, z: float) -> NDArray[np.float64]:
     return T
 
 
+def urdf_transform(
+    xyz: tuple[float, float, float],
+    rpy: tuple[float, float, float],
+) -> NDArray[np.float64]:
+    """Create a 4x4 transform from URDF joint origin (xyz, rpy).
+
+    The URDF convention is ``T = Translation(xyz) @ Rz(yaw) @ Ry(pitch) @ Rx(roll)``.
+    """
+    x, y, z = xyz
+    roll, pitch, yaw = rpy
+    return translation(x, y, z) @ rot_z(yaw) @ rot_y(pitch) @ rot_x(roll)
+
+
 def pose_from_matrix(T: NDArray[np.float64]) -> NDArray[np.float64]:
     """Extract (x, y, z, pitch, roll) from a 4x4 homogeneous matrix.
 

--- a/src/robopy/motor/feetech_bus.py
+++ b/src/robopy/motor/feetech_bus.py
@@ -1,0 +1,299 @@
+# robopy/motor/feetech_bus.py
+
+"""
+FeetechBus for managing multiple Feetech STS/SMS series motors.
+
+Mirrors the interface of DynamixelBus, providing sync_read/sync_write,
+calibration, and error handling for Feetech servos (e.g. STS3215 used
+by the SO-100/SO-101 robot arms).
+"""
+
+import logging
+from enum import Enum
+from types import TracebackType
+from typing import Any, Dict, List, Tuple, Type
+
+import numpy as np
+import scservo_sdk as scs
+from numpy.typing import NDArray
+
+from .feetech_control_table import (
+    FeetechControlItem,
+    STSControlTable,
+    decode_sign_magnitude,
+    encode_sign_magnitude,
+    get_feetech_model_definition,
+)
+
+logger = logging.getLogger(__name__)
+
+BAUDRATE = 1_000_000
+SCS_PROTOCOL_VERSION = 0  # STS3215 uses protocol version 0
+NUM_READ_RETRY = 10
+NUM_WRITE_RETRY = 2
+
+
+class FeetechCommError(ConnectionError):
+    """Exception representing a Feetech communication error."""
+
+    def __init__(self, message: str, comm_result_code: int) -> None:
+        packet_handler = scs.PacketHandler(SCS_PROTOCOL_VERSION)
+        comm_result = packet_handler.getTxRxResult(comm_result_code)
+        super().__init__(f"{message}\n[CommResult: {comm_result}]")
+
+
+class FeetechMotor:
+    """Class that holds the definition and state of an individual Feetech motor."""
+
+    def __init__(self, motor_id: int, motor_name: str, model_name: str) -> None:
+        self.id = motor_id
+        self.motor_name = motor_name
+        self.model_name = model_name
+
+        definition = get_feetech_model_definition(model_name)
+        self.control_table: type[Enum] = definition["control_table"]
+        self.model_number: int = definition["model_number"]
+        self.resolution: int = definition["resolution"]
+
+
+class FeetechBus:
+    """
+    Manages communication with multiple Feetech motors on a single bus.
+    Handles synchronized reading and writing, calibration, and error handling.
+    """
+
+    def __init__(
+        self,
+        port: str,
+        motors: Dict[str, FeetechMotor],
+    ) -> None:
+        self.port_handler = scs.PortHandler(port)
+        self.packet_handler = scs.PacketHandler(SCS_PROTOCOL_VERSION)
+        self.motors = motors
+        # Calibration data: {motor_name: (homing_offset, inverted)}
+        self.calibration: Dict[str, Tuple[int, bool]] = {}
+
+    def open(self, baudrate: int = BAUDRATE) -> None:
+        """Opens the communication port."""
+        if not self.port_handler.openPort():
+            raise ConnectionError(f"Failed to open port {self.port_handler.port_name}.")
+        if not self.port_handler.setBaudRate(baudrate):
+            raise ConnectionError(f"Failed to set baudrate to {baudrate}.")
+        logger.info(f"Opened Feetech port {self.port_handler.port_name} (Baudrate: {baudrate})")
+
+    def close(self) -> None:
+        """Closes the communication port."""
+        self.port_handler.closePort()
+        logger.info(f"Closed Feetech port {self.port_handler.port_name}.")
+
+    def __enter__(self) -> "FeetechBus":
+        self.open()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def set_calibration(self, calibration_data: Dict[str, Tuple[int, bool]]) -> None:
+        """Sets the calibration data for the motors."""
+        self.calibration = calibration_data
+        logger.info("Feetech calibration data set.")
+
+    def _split_into_byte_chunks(self, value: int, length: int) -> List[int]:
+        """Converts an integer value into a list of bytes for transmission (little-endian)."""
+        if length == 1:
+            return [value & 0xFF]
+        if length == 2:
+            return [scs.SCS_LOBYTE(value), scs.SCS_HIBYTE(value)]
+        raise ValueError(f"Unsupported byte length: {length}")
+
+    def sync_write(self, item: Enum, values: Dict[str, int | float]) -> None:
+        """
+        Writes values to a specific control table item for multiple motors simultaneously.
+
+        Example:
+            bus.sync_write(STSControlTable.TORQUE_ENABLE, {"motor1": 1, "motor2": 1})
+        """
+        if not isinstance(item.value, FeetechControlItem):
+            raise TypeError("Item must be an Enum member with a FeetechControlItem value.")
+
+        control_item: FeetechControlItem = item.value
+        group_sync_write = scs.GroupSyncWrite(
+            self.port_handler, self.packet_handler, control_item.address, control_item.num_bytes
+        )
+
+        processed_values = np.array([values[name] for name in self.motors if name in values])
+        motor_names_to_write = [name for name in self.motors if name in values]
+
+        # Apply inverse calibration if needed (degrees to steps)
+        if control_item.calibration_required and self.calibration:
+            processed_values = self._revert_calibration(processed_values, motor_names_to_write)
+
+        # Add parameters to the sync write group
+        for i, name in enumerate(motor_names_to_write):
+            motor = self.motors[name]
+            if motor.control_table != item.__class__:
+                logger.warning(f"Skipping {name} due to mismatched control table.")
+                continue
+
+            raw_value = int(processed_values[i])
+
+            # Apply sign-magnitude encoding if required
+            if control_item.sign_magnitude_bit is not None:
+                raw_value = encode_sign_magnitude(raw_value, control_item.sign_magnitude_bit)
+
+            data = self._split_into_byte_chunks(raw_value, control_item.num_bytes)
+            if not group_sync_write.addParam(motor.id, data):
+                logger.error(f"Failed to add parameter for {name} (ID-{motor.id}).")
+
+        # Transmit the packet with retries
+        comm_result = scs.COMM_TX_FAIL
+        for _ in range(NUM_WRITE_RETRY):
+            comm_result = group_sync_write.txPacket()
+            if comm_result == scs.COMM_SUCCESS:
+                return
+
+        raise FeetechCommError(f"Failed to sync write {item.name}.", comm_result)
+
+    def sync_read(self, item: Enum, motor_names: List[str]) -> Dict[str, Any]:
+        """
+        Reads values from a specific control table item for multiple motors simultaneously.
+
+        Example:
+            positions = bus.sync_read(STSControlTable.PRESENT_POSITION, ["motor1", "motor2"])
+        """
+        if not isinstance(item.value, FeetechControlItem):
+            raise TypeError("Item must be an Enum member with a FeetechControlItem value.")
+
+        control_item: FeetechControlItem = item.value
+        group_sync_read = scs.GroupSyncRead(
+            self.port_handler, self.packet_handler, control_item.address, control_item.num_bytes
+        )
+
+        # Add parameters to the sync read group
+        motors_to_read: List[FeetechMotor] = []
+        for name in motor_names:
+            if name not in self.motors:
+                continue
+            motor = self.motors[name]
+            if motor.control_table == item.__class__:
+                group_sync_read.addParam(motor.id)
+                motors_to_read.append(motor)
+
+        # Transmit the packet with retries
+        comm_result = scs.COMM_TX_FAIL
+        for _ in range(NUM_READ_RETRY):
+            comm_result = group_sync_read.txRxPacket()
+            if comm_result == scs.COMM_SUCCESS:
+                break
+        else:
+            raise FeetechCommError(f"Failed to sync read {item.name}.", comm_result)
+
+        # Process received data
+        raw_values = []
+        results: Dict[str, Any] = {}
+        for motor in motors_to_read:
+            if group_sync_read.isAvailable(motor.id, control_item.address, control_item.num_bytes):
+                raw_value = group_sync_read.getData(
+                    motor.id, control_item.address, control_item.num_bytes
+                )
+
+                # Decode sign-magnitude if required
+                if control_item.sign_magnitude_bit is not None:
+                    raw_value = decode_sign_magnitude(raw_value, control_item.sign_magnitude_bit)
+
+                results[motor.motor_name] = raw_value
+                raw_values.append(raw_value)
+
+        if control_item.calibration_required and self.calibration:
+            calibrated_values = self._apply_calibration(
+                np.array(raw_values), [m.motor_name for m in motors_to_read]
+            )
+            for i, motor in enumerate(motors_to_read):
+                results[motor.motor_name] = calibrated_values[i]
+
+        return results
+
+    def _apply_calibration(
+        self,
+        values: NDArray[np.int32],
+        motor_names: List[str],
+    ) -> NDArray[np.float32]:
+        """Converts raw motor steps (int32) to calibrated degrees (float32)."""
+        values = values.astype(np.int32)
+        for i, name in enumerate(motor_names):
+            if name not in self.calibration:
+                continue
+            homing_offset, inverted = self.calibration[name]
+            if inverted:
+                values[i] *= -1
+            values[i] += homing_offset
+
+        # Convert from steps to degrees
+        float_values = values.astype(np.float32)
+        for i, name in enumerate(motor_names):
+            resolution = self.motors[name].resolution
+            float_values[i] = float_values[i] / (resolution / 2) * 180
+
+        return float_values
+
+    def _revert_calibration(
+        self,
+        values: NDArray[np.float32],
+        motor_names: List[str],
+    ) -> NDArray[np.int32]:
+        """Converts calibrated degrees (float32) back to raw motor steps (int32)."""
+        # Convert from degrees to steps
+        step_values = values.astype(np.float32)
+        for i, name in enumerate(motor_names):
+            resolution = self.motors[name].resolution
+            step_values[i] = step_values[i] / 180 * (resolution / 2)
+
+        int_values = np.round(step_values).astype(np.int32)
+
+        for i, name in enumerate(motor_names):
+            if name not in self.calibration:
+                continue
+            homing_offset, inverted = self.calibration[name]
+            int_values[i] -= homing_offset
+            if inverted:
+                int_values[i] *= -1
+
+        return int_values
+
+    def read(self, item: Enum, motor_name: str) -> Any:
+        """Reads a value from a specific control table item for a single motor."""
+        result = self.sync_read(item, [motor_name])
+        return result.get(motor_name)
+
+    def write(self, item: Enum, motor_name: str, value: int | float) -> None:
+        """Writes a value to a specific control table item for a single motor."""
+        self.sync_write(item, {motor_name: value})
+
+    def torque_disabled(self, specific_motor_names: List[str] | None = None) -> None:
+        """Disable torque for multiple motors."""
+        motor_names: List[str]
+        if specific_motor_names is None:
+            motor_names = list(self.motors.keys())
+        else:
+            motor_names = specific_motor_names
+        torque_off_values: Dict[str, int | float] = {name: 0 for name in motor_names}
+        self.sync_write(STSControlTable.TORQUE_ENABLE, torque_off_values)
+
+    def torque_enabled(self, specific_motor_names: List[str] | None = None) -> None:
+        """Enable torque for multiple motors."""
+        motor_names: List[str]
+        if specific_motor_names is None:
+            motor_names = list(self.motors.keys())
+        else:
+            motor_names = specific_motor_names
+        torque_on_values: Dict[str, int | float] = {name: 1 for name in motor_names}
+        self.sync_write(STSControlTable.TORQUE_ENABLE, torque_on_values)
+
+    def __repr__(self) -> str:
+        motor_list = ", ".join(self.motors.keys())
+        return f"FeetechBus(port={self.port_handler.port_name}, motors=[{motor_list}])"

--- a/src/robopy/motor/feetech_bus.py
+++ b/src/robopy/motor/feetech_bus.py
@@ -202,6 +202,10 @@ class FeetechBus:
 
             import select
 
+            # Track if this is the first iteration
+            first_iteration = True
+            num_display_lines = len(motor_names)
+
             while True:
                 positions = self.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
                 for name in motor_names:
@@ -211,14 +215,21 @@ class FeetechBus:
                     if val > range_maxes[name]:
                         range_maxes[name] = val
 
-                # Display current tracking
-                parts = []
+                # Move cursor up to overwrite previous output (except on first iteration)
+                if not first_iteration:
+                    # Move cursor up by num_display_lines
+                    print(f"\033[{num_display_lines}A", end="")
+                first_iteration = False
+
+                # Display current tracking - one line per motor
                 for name in motor_names:
-                    parts.append(
-                        f"  {name}: min={range_mins[name]}, "
-                        f"cur={int(positions[name])}, max={range_maxes[name]}"
+                    # Clear the line and print motor info
+                    print(
+                        f"\033[K  {name:15s}: "
+                        f"min={range_mins[name]:4d}, "
+                        f"cur={int(positions[name]):4d}, "
+                        f"max={range_maxes[name]:4d}"
                     )
-                print("\r" + " | ".join(parts) + "    ", end="", flush=True)
 
                 # Check if Enter was pressed
                 if select.select([sys.stdin], [], [], 0.02)[0]:

--- a/src/robopy/motor/feetech_control_table.py
+++ b/src/robopy/motor/feetech_control_table.py
@@ -1,0 +1,147 @@
+# robopy/motor/feetech_control_table.py
+
+"""
+Control table definitions for Feetech STS/SMS series motors (e.g. STS3215).
+
+This module mirrors the structure of control_table.py for Dynamixel motors,
+providing Enum-based access to the STS3215 control table and sign-magnitude
+encoding utilities required by the Feetech protocol.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Literal, TypedDict
+
+from .control_table import Dtype
+
+
+@dataclass
+class FeetechControlItem:
+    """
+    Represents an item in the Feetech STS/SMS control table.
+
+    Attributes:
+        address: The memory address of the item.
+        num_bytes: The size of the data in bytes (1 or 2).
+        dtype: The data type of the item.
+        access: Access mode ("R" for read, "R/W" for read/write).
+        calibration_required: Flag indicating if this item requires calibration.
+        sign_magnitude_bit: If set, the value uses sign-magnitude encoding
+            at this bit index (e.g. 15 for positions, 11 for homing offset).
+    """
+
+    address: int
+    num_bytes: Literal[1, 2]
+    dtype: Dtype
+    access: Literal["R", "R/W"]
+    calibration_required: bool = field(default=False, kw_only=True)
+    sign_magnitude_bit: int | None = field(default=None, kw_only=True)
+
+
+class STSControlTable(Enum):
+    """Control table for Feetech STS-series motors (STS3215, etc.)."""
+
+    # --- EPROM (persistent) ---
+    MODEL_NUMBER = FeetechControlItem(3, 2, Dtype.UINT16, "R")
+    ID = FeetechControlItem(5, 1, Dtype.UINT8, "R/W")
+    BAUD_RATE = FeetechControlItem(6, 1, Dtype.UINT8, "R/W")
+    RETURN_DELAY_TIME = FeetechControlItem(7, 1, Dtype.UINT8, "R/W")
+    MIN_POSITION_LIMIT = FeetechControlItem(9, 2, Dtype.UINT16, "R/W")
+    MAX_POSITION_LIMIT = FeetechControlItem(11, 2, Dtype.UINT16, "R/W")
+    MAX_TEMPERATURE_LIMIT = FeetechControlItem(13, 1, Dtype.UINT8, "R")
+    MAX_VOLTAGE_LIMIT = FeetechControlItem(14, 1, Dtype.UINT8, "R")
+    MIN_VOLTAGE_LIMIT = FeetechControlItem(15, 1, Dtype.UINT8, "R")
+    MAX_TORQUE_LIMIT = FeetechControlItem(16, 2, Dtype.UINT16, "R/W")
+    P_COEFFICIENT = FeetechControlItem(21, 1, Dtype.UINT8, "R/W")
+    D_COEFFICIENT = FeetechControlItem(22, 1, Dtype.UINT8, "R/W")
+    I_COEFFICIENT = FeetechControlItem(23, 1, Dtype.UINT8, "R/W")
+    PROTECTION_CURRENT = FeetechControlItem(28, 2, Dtype.UINT16, "R/W")
+    HOMING_OFFSET = FeetechControlItem(
+        31, 2, Dtype.INT16, "R/W", sign_magnitude_bit=11
+    )
+    OPERATING_MODE = FeetechControlItem(33, 1, Dtype.UINT8, "R/W")
+    PROTECTIVE_TORQUE = FeetechControlItem(34, 1, Dtype.UINT8, "R/W")
+    PROTECTION_TIME = FeetechControlItem(35, 1, Dtype.UINT8, "R/W")
+    OVERLOAD_TORQUE = FeetechControlItem(36, 1, Dtype.UINT8, "R/W")
+
+    # --- SRAM (runtime) ---
+    TORQUE_ENABLE = FeetechControlItem(40, 1, Dtype.UINT8, "R/W")
+    ACCELERATION = FeetechControlItem(41, 1, Dtype.UINT8, "R/W")
+    GOAL_POSITION = FeetechControlItem(
+        42, 2, Dtype.INT16, "R/W",
+        calibration_required=True, sign_magnitude_bit=15,
+    )
+    GOAL_VELOCITY = FeetechControlItem(
+        46, 2, Dtype.INT16, "R/W", sign_magnitude_bit=15,
+    )
+    TORQUE_LIMIT = FeetechControlItem(48, 2, Dtype.UINT16, "R/W")
+    LOCK = FeetechControlItem(55, 1, Dtype.UINT8, "R/W")
+    PRESENT_POSITION = FeetechControlItem(
+        56, 2, Dtype.INT16, "R",
+        calibration_required=True, sign_magnitude_bit=15,
+    )
+    PRESENT_VELOCITY = FeetechControlItem(58, 2, Dtype.INT16, "R")
+    PRESENT_LOAD = FeetechControlItem(
+        60, 2, Dtype.INT16, "R", sign_magnitude_bit=10,
+    )
+    PRESENT_VOLTAGE = FeetechControlItem(62, 1, Dtype.UINT8, "R")
+    PRESENT_TEMPERATURE = FeetechControlItem(63, 1, Dtype.UINT8, "R")
+    PRESENT_CURRENT = FeetechControlItem(69, 2, Dtype.UINT16, "R")
+
+
+# --- Model Specific Definitions ---
+
+
+class FeetechModelDefinition(TypedDict):
+    """Typed dictionary for a Feetech motor model's definition."""
+
+    model_number: int
+    control_table: type[Enum]
+    resolution: int
+
+
+FEETECH_MODEL_DEFINITIONS: Dict[str, FeetechModelDefinition] = {
+    "sts3215": {
+        "model_number": 777,
+        "control_table": STSControlTable,
+        "resolution": 4096,
+    },
+    "sts3250": {
+        "model_number": 2825,
+        "control_table": STSControlTable,
+        "resolution": 4096,
+    },
+}
+
+
+def get_feetech_model_definition(model_name: str) -> FeetechModelDefinition:
+    """Retrieves the definition for a given Feetech motor model name."""
+    if model_name not in FEETECH_MODEL_DEFINITIONS:
+        raise ValueError(f"Feetech model '{model_name}' is not defined.")
+    return FEETECH_MODEL_DEFINITIONS[model_name]
+
+
+# --- Sign-Magnitude Encoding Utilities ---
+
+
+def decode_sign_magnitude(encoded_value: int, sign_bit_index: int) -> int:
+    """Decodes a sign-magnitude encoded value to a signed integer.
+
+    In Feetech's encoding, the sign bit indicates direction:
+    0 = positive, 1 = negative. The remaining bits are the magnitude.
+    """
+    direction_bit = (encoded_value >> sign_bit_index) & 1
+    magnitude_mask = (1 << sign_bit_index) - 1
+    magnitude = encoded_value & magnitude_mask
+    return -magnitude if direction_bit else magnitude
+
+
+def encode_sign_magnitude(value: int, sign_bit_index: int) -> int:
+    """Encodes a signed integer into sign-magnitude format.
+
+    The sign bit is placed at sign_bit_index. Magnitude occupies lower bits.
+    """
+    max_magnitude = (1 << sign_bit_index) - 1
+    magnitude = min(abs(value), max_magnitude)
+    direction_bit = 1 if value < 0 else 0
+    return (direction_bit << sign_bit_index) | magnitude

--- a/src/robopy/motor/feetech_control_table.py
+++ b/src/robopy/motor/feetech_control_table.py
@@ -56,9 +56,7 @@ class STSControlTable(Enum):
     D_COEFFICIENT = FeetechControlItem(22, 1, Dtype.UINT8, "R/W")
     I_COEFFICIENT = FeetechControlItem(23, 1, Dtype.UINT8, "R/W")
     PROTECTION_CURRENT = FeetechControlItem(28, 2, Dtype.UINT16, "R/W")
-    HOMING_OFFSET = FeetechControlItem(
-        31, 2, Dtype.INT16, "R/W", sign_magnitude_bit=11
-    )
+    HOMING_OFFSET = FeetechControlItem(31, 2, Dtype.INT16, "R/W", sign_magnitude_bit=11)
     OPERATING_MODE = FeetechControlItem(33, 1, Dtype.UINT8, "R/W")
     PROTECTIVE_TORQUE = FeetechControlItem(34, 1, Dtype.UINT8, "R/W")
     PROTECTION_TIME = FeetechControlItem(35, 1, Dtype.UINT8, "R/W")
@@ -68,21 +66,37 @@ class STSControlTable(Enum):
     TORQUE_ENABLE = FeetechControlItem(40, 1, Dtype.UINT8, "R/W")
     ACCELERATION = FeetechControlItem(41, 1, Dtype.UINT8, "R/W")
     GOAL_POSITION = FeetechControlItem(
-        42, 2, Dtype.INT16, "R/W",
-        calibration_required=True, sign_magnitude_bit=15,
+        42,
+        2,
+        Dtype.INT16,
+        "R/W",
+        calibration_required=True,
+        sign_magnitude_bit=15,
     )
     GOAL_VELOCITY = FeetechControlItem(
-        46, 2, Dtype.INT16, "R/W", sign_magnitude_bit=15,
+        46,
+        2,
+        Dtype.INT16,
+        "R/W",
+        sign_magnitude_bit=15,
     )
     TORQUE_LIMIT = FeetechControlItem(48, 2, Dtype.UINT16, "R/W")
     LOCK = FeetechControlItem(55, 1, Dtype.UINT8, "R/W")
     PRESENT_POSITION = FeetechControlItem(
-        56, 2, Dtype.INT16, "R",
-        calibration_required=True, sign_magnitude_bit=15,
+        56,
+        2,
+        Dtype.INT16,
+        "R",
+        calibration_required=True,
+        sign_magnitude_bit=15,
     )
     PRESENT_VELOCITY = FeetechControlItem(58, 2, Dtype.INT16, "R")
     PRESENT_LOAD = FeetechControlItem(
-        60, 2, Dtype.INT16, "R", sign_magnitude_bit=10,
+        60,
+        2,
+        Dtype.INT16,
+        "R",
+        sign_magnitude_bit=10,
     )
     PRESENT_VOLTAGE = FeetechControlItem(62, 1, Dtype.UINT8, "R")
     PRESENT_TEMPERATURE = FeetechControlItem(63, 1, Dtype.UINT8, "R")

--- a/src/robopy/robots/__init__.py
+++ b/src/robopy/robots/__init__.py
@@ -7,6 +7,10 @@ from .rakuda.rakuda_follower import RakudaFollower
 from .rakuda.rakuda_leader import RakudaLeader
 from .rakuda.rakuda_pair_sys import RakudaPairSys
 from .rakuda.rakuda_robot import RakudaRobot
+from .so101.so101_follower import So101Follower
+from .so101.so101_leader import So101Leader
+from .so101.so101_pair_sys import So101PairSys
+from .so101.so101_robot import So101Robot
 
 __all__ = [
     "RakudaRobot",
@@ -18,4 +22,8 @@ __all__ = [
     "KochPairSys",
     "KochLeader",
     "KochFollower",
+    "So101Robot",
+    "So101PairSys",
+    "So101Leader",
+    "So101Follower",
 ]

--- a/src/robopy/robots/common/arm.py
+++ b/src/robopy/robots/common/arm.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 
 from robopy.motor.dynamixel_bus import DynamixelBus
+from robopy.motor.feetech_bus import FeetechBus
+
+MotorBus = DynamixelBus | FeetechBus
 
 
 class Arm(ABC):
@@ -14,7 +17,7 @@ class Arm(ABC):
 
     @property
     @abstractmethod
-    def motors(self) -> DynamixelBus | None:
+    def motors(self) -> MotorBus | None:
         """Abstract property for motors"""
         pass
 

--- a/src/robopy/robots/koch/koch_robot.py
+++ b/src/robopy/robots/koch/koch_robot.py
@@ -510,7 +510,7 @@ class KochRobot(ComposedRobot[KochPairSys, Sensors, KochObs]):
             obs = self.get_arm_observation()
             current_joint_angles_deg = obs.follower
 
-        result = self.inverse_kinematics(ee, current_joint_angles_deg)
+        result = self.inverse_kinematics(ee.astype(np.float32), current_joint_angles_deg)
 
         if not result.success:
             logger.warning(

--- a/src/robopy/robots/koch/koch_robot.py
+++ b/src/robopy/robots/koch/koch_robot.py
@@ -3,7 +3,7 @@ import threading
 import time
 from collections import defaultdict
 from logging import getLogger
-from typing import DefaultDict, Dict, List
+from typing import ClassVar, DefaultDict, Dict, List
 
 import numpy as np
 from numpy.typing import NDArray
@@ -19,6 +19,8 @@ from robopy.config.sensor_config.visual_config.camera_config import (
     RealsenseCameraConfig,
     WebCameraConfig,
 )
+from robopy.kinematics import EEPose, IKConfig, IKResult, IKSolver, koch_chain
+from robopy.kinematics.chain import KinematicChain
 from robopy.robots.common.composed import ComposedRobot
 from robopy.sensors.visual.realsense_camera import RealsenseCamera
 from robopy.sensors.visual.web_camera import WebCamera
@@ -30,6 +32,8 @@ logger = getLogger(__name__)
 
 
 class KochRobot(ComposedRobot[KochPairSys, Sensors, KochObs]):
+    _kinematic_chain: ClassVar[KinematicChain | None] = None
+
     def __init__(self, cfg: KochConfig) -> None:
         super().__init__()
         self.config = self._init_config(cfg)
@@ -37,6 +41,7 @@ class KochRobot(ComposedRobot[KochPairSys, Sensors, KochObs]):
         self._robot_system = KochPairSys(self.config)
         self._sensors = self._init_sensors()
         self._cameras: List[WebCamera | RealsenseCamera] = list(self._sensors.cameras or [])
+        self._ik_solver: IKSolver | None = None
 
     def connect(self) -> None:
         try:
@@ -398,6 +403,178 @@ class KochRobot(ComposedRobot[KochPairSys, Sensors, KochObs]):
                 follower_goals[follower_name] = float(leader_action[i])
 
         self._robot_system.send_follower_action(follower_goals)
+
+    # ------------------------------------------------------------------
+    # Kinematics: FK / IK / EE-space actions
+    #
+    # WARNING: Koch has no official URDF.  The kinematic parameters used
+    # here are rough estimates from MuJoCo menagerie and CAD drawings.
+    # See ``robopy.kinematics.robot_chains.koch_chain`` for details and
+    # TODO(physical-params) markers.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def kinematic_chain(cls) -> KinematicChain:
+        """Get the Koch kinematic chain (lazy-initialised, shared)."""
+        if cls._kinematic_chain is None:
+            cls._kinematic_chain = koch_chain()
+        return cls._kinematic_chain
+
+    @classmethod
+    def forward_kinematics(cls, joint_angles_deg: NDArray[np.float32]) -> EEPose:
+        """Compute FK from joint angles (degrees) to end-effector pose.
+
+        Args:
+            joint_angles_deg: (5,) or (6,) array of joint angles in degrees.
+                If 6 values are given the last element (gripper) is ignored.
+
+        Returns:
+            EEPose with position in metres and orientation in radians.
+        """
+        angles = np.asarray(joint_angles_deg, dtype=np.float64)
+        if len(angles) == 6:
+            angles = angles[:5]
+        if len(angles) != 5:
+            raise ValueError(f"Expected 5 or 6 joint angles, got {len(angles)}")
+
+        angles_rad = np.deg2rad(angles)
+        chain = cls.kinematic_chain()
+        pose = chain.forward_kinematics(angles_rad)
+        return EEPose.from_array(pose)
+
+    def _get_ik_solver(self) -> IKSolver:
+        """Get or create the IK solver instance."""
+        if self._ik_solver is None:
+            self._ik_solver = IKSolver(self.kinematic_chain())
+        return self._ik_solver
+
+    def inverse_kinematics(
+        self,
+        target_pose: EEPose | NDArray[np.float32],
+        current_joint_angles_deg: NDArray[np.float32],
+        ik_config: IKConfig | None = None,
+    ) -> IKResult:
+        """Solve IK for a target end-effector pose.
+
+        Args:
+            target_pose: Desired EE pose (EEPose or (5,) array
+                ``[x, y, z, pitch, roll]``).
+            current_joint_angles_deg: (5,) or (6,) current joint angles in
+                degrees used as the initial guess.
+            ik_config: Optional override for solver parameters.
+
+        Returns:
+            IKResult with ``joint_angles_rad`` in radians.
+        """
+        if isinstance(target_pose, EEPose):
+            target = target_pose.to_array()
+        else:
+            target = np.asarray(target_pose, dtype=np.float64)
+
+        current = np.asarray(current_joint_angles_deg, dtype=np.float64)
+        if len(current) == 6:
+            current = current[:5]
+        current_rad = np.deg2rad(current)
+
+        solver = self._get_ik_solver()
+        if ik_config is not None:
+            solver = IKSolver(self.kinematic_chain(), ik_config)
+
+        return solver.solve(target, current_rad)
+
+    def send_ee_frame_action(
+        self,
+        ee_action: NDArray[np.float32],
+        current_joint_angles_deg: NDArray[np.float32] | None = None,
+        gripper_deg: float = 0.0,
+    ) -> None:
+        """Send a single end-effector pose action to the robot.
+
+        Args:
+            ee_action: (5,) array ``[x, y, z, pitch, roll]`` **or** (6,) array
+                ``[x, y, z, pitch, roll, gripper_deg]``.
+            current_joint_angles_deg: (5,) or (6,) current joint angles in
+                degrees.  If *None* the current follower positions are read.
+            gripper_deg: Gripper angle in degrees (used when *ee_action* is
+                5-dimensional).
+        """
+        if not self.is_connected:
+            raise ConnectionError("KochRobot is not connected. Call connect() first.")
+
+        ee = np.asarray(ee_action, dtype=np.float64)
+        if len(ee) == 6:
+            gripper_deg = float(ee[5])
+            ee = ee[:5]
+
+        if current_joint_angles_deg is None:
+            obs = self.get_arm_observation()
+            current_joint_angles_deg = obs.follower
+
+        result = self.inverse_kinematics(ee, current_joint_angles_deg)
+
+        if not result.success:
+            logger.warning(
+                "IK did not converge (best-effort). pos_err=%.4f m, ori_err=%.4f rad",
+                result.position_error,
+                result.orientation_error,
+            )
+
+        joint_deg = np.rad2deg(result.joint_angles_rad).astype(np.float32)
+        full_action = np.append(joint_deg, np.float32(gripper_deg))
+        self.send_frame_action(full_action)
+
+    def send_ee(
+        self,
+        max_frame: int,
+        fps: int,
+        ee_actions: NDArray[np.float32],
+        teleop_hz: int = 100,
+    ) -> None:
+        """Send a trajectory of end-effector poses to the robot.
+
+        Each row of *ee_actions* is converted to joint angles via IK.  The
+        previous frame's solution is used as the seed for the next frame so
+        that the resulting joint trajectory is smooth.
+
+        Args:
+            max_frame: Number of frames in the trajectory.
+            fps: Playback frame-rate.
+            ee_actions: (max_frame, 5) or (max_frame, 6) end-effector poses.
+                If 6 columns, the last column is the gripper angle in degrees.
+            teleop_hz: Motor command rate.
+        """
+        if not self.is_connected:
+            raise ConnectionError("KochRobot is not connected. Call connect() first.")
+
+        if ee_actions.shape[0] != max_frame:
+            raise ValueError("ee_actions length must match max_frame.")
+
+        obs = self.get_arm_observation()
+        current_joints = obs.follower  # (6,) degrees
+
+        joint_actions = np.zeros((max_frame, 6), dtype=np.float32)
+        for i in range(max_frame):
+            ee = ee_actions[i]
+            if len(ee) >= 6:
+                gripper = float(ee[5])
+                ee_5 = ee[:5]
+            else:
+                gripper = float(current_joints[5]) if len(current_joints) > 5 else 0.0
+                ee_5 = ee
+
+            result = self.inverse_kinematics(ee_5, current_joints)
+            joint_deg = np.rad2deg(result.joint_angles_rad).astype(np.float32)
+            joint_actions[i, :5] = joint_deg
+            joint_actions[i, 5] = gripper
+
+            # Use this solution as seed for the next frame
+            current_joints = joint_actions[i]
+
+        self.send(max_frame, fps, joint_actions, teleop_hz)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
 
     def _init_config(self, cfg: KochConfig) -> KochConfig:
         if cfg.sensors is None:

--- a/src/robopy/robots/so101/__init__.py
+++ b/src/robopy/robots/so101/__init__.py
@@ -4,5 +4,12 @@ from .so101_follower import So101Follower
 from .so101_leader import So101Leader
 from .so101_pair_sys import So101PairSys
 from .so101_robot import So101Robot
+from .so101_spacemouse import So101SpaceMouseController
 
-__all__ = ["So101Follower", "So101Leader", "So101PairSys", "So101Robot"]
+__all__ = [
+    "So101Follower",
+    "So101Leader",
+    "So101PairSys",
+    "So101Robot",
+    "So101SpaceMouseController",
+]

--- a/src/robopy/robots/so101/__init__.py
+++ b/src/robopy/robots/so101/__init__.py
@@ -1,0 +1,8 @@
+"""SO-101 robot modules."""
+
+from .so101_follower import So101Follower
+from .so101_leader import So101Leader
+from .so101_pair_sys import So101PairSys
+from .so101_robot import So101Robot
+
+__all__ = ["So101Follower", "So101Leader", "So101PairSys", "So101Robot"]

--- a/src/robopy/robots/so101/calibration.py
+++ b/src/robopy/robots/so101/calibration.py
@@ -1,0 +1,128 @@
+# robopy/robots/so101/calibration.py
+
+"""
+Calibration procedure for SO-101 arms using Feetech STS3215 motors.
+
+The STS3215 uses a 12-bit encoder (0-4095 steps per rotation).
+Calibration determines a homing offset and drive mode (inversion) for each
+motor so that the zero-degree position matches a known physical pose.
+"""
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from robopy.motor.feetech_bus import FeetechBus
+from robopy.motor.feetech_control_table import STSControlTable
+from robopy.robots.common.arm import Arm
+
+ZERO_POSITION_DEGREE = 0
+ROTATED_POSITION_DEGREE = 90
+
+
+def convert_degrees_to_steps(degrees: float, resolutions: List[int]) -> NDArray[np.int_]:
+    """Converts degrees to motor steps based on motor resolutions."""
+    steps = np.array(degrees) / 180.0 * np.array(resolutions) / 2.0
+    return steps.astype(int)
+
+
+def assert_drive_mode(drive_mode: NDArray[np.int_]) -> None:
+    if not np.all(np.isin(drive_mode, [0, 1])):
+        raise ValueError(f"`drive_mode` contains values other than 0 or 1: ({drive_mode})")
+
+
+def apply_drive_mode(position: NDArray[np.int_], drive_mode: NDArray[np.int_]) -> NDArray[np.int_]:
+    assert_drive_mode(drive_mode)
+    signed_drive_mode = -(drive_mode * 2 - 1)
+    position *= signed_drive_mode
+    return position
+
+
+def reset_torque_and_set_mode(arm: Arm) -> None:
+    """Disables torque and sets the correct operating modes for calibration."""
+    bus = arm.motors
+    if bus is None:
+        raise RuntimeError(f"Motors for {arm} are not initialized.")
+    if not isinstance(bus, FeetechBus):
+        raise TypeError("SO-101 calibration requires a FeetechBus.")
+
+    all_motor_names = arm.motor_names
+
+    # Disable torque for all motors
+    disable_torque_values: Dict[str, int | float] = {name: 0 for name in all_motor_names}
+    bus.sync_write(STSControlTable.TORQUE_ENABLE, disable_torque_values)
+
+    # Set position mode (mode 0) for all motors
+    position_mode_values: Dict[str, int | float] = {name: 0 for name in all_motor_names}
+    bus.sync_write(STSControlTable.OPERATING_MODE, position_mode_values)
+
+
+def run_arm_calibration(arm: Arm, arm_type: str) -> Dict[str, Tuple[int, bool]]:
+    """
+    Runs the interactive calibration procedure for a single SO-101 arm.
+    This function determines the homing offset and drive mode for each motor.
+    """
+    reset_torque_and_set_mode(arm)
+
+    if arm.motors is None:
+        raise RuntimeError(f"Motors for {arm_type} arm are not initialized.")
+
+    motor_names = arm.motor_names
+    resolutions = [arm.motors.motors[name].resolution for name in motor_names]
+
+    print(f"\n>> Running calibration of the SO-101 {arm_type} arm...")
+
+    print("\n[Step 1/2] Move the arm to the ZERO position.")
+    print("  All joints should be at their neutral/zero angle.")
+    input("Press Enter when ready...")
+
+    # --- Homing Offset Calculation (First Pass) ---
+    zero_pos_steps = convert_degrees_to_steps(ZERO_POSITION_DEGREE, resolutions)
+
+    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
+    current_pos = np.array([pos_dict[name] for name in motor_names])
+
+    # Round to nearest quarter turn to reduce manual positioning errors
+    quarter_turn_steps = convert_degrees_to_steps(90, resolutions)
+    rounded_pos = np.round(current_pos.astype(float) / quarter_turn_steps) * quarter_turn_steps
+
+    homing_offset = zero_pos_steps - rounded_pos.astype(int)
+
+    # --- Drive Mode Calculation ---
+    print("\n[Step 2/2] Move the arm to the ROTATED position.")
+    print("  Rotate each joint approximately +90 degrees from the zero position.")
+    input("Press Enter when ready...")
+
+    rotated_pos_steps = convert_degrees_to_steps(ROTATED_POSITION_DEGREE, resolutions)
+
+    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
+    current_pos = np.array([pos_dict[name] for name in motor_names])
+
+    # Apply preliminary offset and round
+    pos_with_offset = current_pos + homing_offset
+    rounded_pos = np.round(pos_with_offset.astype(float) / quarter_turn_steps) * quarter_turn_steps
+
+    # If the rounded position doesn't match the target, the drive mode is inverted
+    drive_mode = (rounded_pos != rotated_pos_steps).astype(np.int32)
+
+    # --- Homing Offset Refinement (Second Pass) ---
+    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
+    current_pos = np.array([pos_dict[name] for name in motor_names])
+
+    pos_with_drive_mode = apply_drive_mode(current_pos, drive_mode)
+    rounded_pos = (
+        np.round(pos_with_drive_mode.astype(float) / quarter_turn_steps) * quarter_turn_steps
+    )
+
+    homing_offset = rotated_pos_steps - rounded_pos.astype(int)
+
+    print("\nCalibration for this arm is complete. Please move it to a safe rest position.")
+    input("Press Enter to continue...")
+
+    # --- Format and Return Calibration Data ---
+    calibration_data = {
+        name: (int(homing_offset[i]), bool(drive_mode[i])) for i, name in enumerate(motor_names)
+    }
+
+    return calibration_data

--- a/src/robopy/robots/so101/calibration.py
+++ b/src/robopy/robots/so101/calibration.py
@@ -3,44 +3,28 @@
 """
 Calibration procedure for SO-101 arms using Feetech STS3215 motors.
 
-The STS3215 uses a 12-bit encoder (0-4095 steps per rotation).
-Calibration determines a homing offset and drive mode (inversion) for each
-motor so that the zero-degree position matches a known physical pose.
+Matches the latest lerobot calibration approach:
+1. Move arm to the middle of its range → compute homing offsets (half-turn centering)
+2. Move all joints through their full range → record min/max positions
+3. wrist_roll is treated as a full-rotation joint (range 0–4095)
+
+The calibration data is stored as a dict of MotorCalibration per motor.
 """
 
-from typing import Dict, List, Tuple
+import logging
+from typing import Dict
 
-import numpy as np
-from numpy.typing import NDArray
-
-from robopy.motor.feetech_bus import FeetechBus
+from robopy.motor.feetech_bus import FeetechBus, MotorCalibration
 from robopy.motor.feetech_control_table import STSControlTable
 from robopy.robots.common.arm import Arm
 
-ZERO_POSITION_DEGREE = 0
-ROTATED_POSITION_DEGREE = 90
+logger = logging.getLogger(__name__)
+
+FULL_TURN_MOTOR = "wrist_roll"
 
 
-def convert_degrees_to_steps(degrees: float, resolutions: List[int]) -> NDArray[np.int_]:
-    """Converts degrees to motor steps based on motor resolutions."""
-    steps = np.array(degrees) / 180.0 * np.array(resolutions) / 2.0
-    return steps.astype(int)
-
-
-def assert_drive_mode(drive_mode: NDArray[np.int_]) -> None:
-    if not np.all(np.isin(drive_mode, [0, 1])):
-        raise ValueError(f"`drive_mode` contains values other than 0 or 1: ({drive_mode})")
-
-
-def apply_drive_mode(position: NDArray[np.int_], drive_mode: NDArray[np.int_]) -> NDArray[np.int_]:
-    assert_drive_mode(drive_mode)
-    signed_drive_mode = -(drive_mode * 2 - 1)
-    position *= signed_drive_mode
-    return position
-
-
-def reset_torque_and_set_mode(arm: Arm) -> None:
-    """Disables torque and sets the correct operating modes for calibration."""
+def _disable_torque_and_set_position_mode(arm: Arm) -> FeetechBus:
+    """Disables torque and sets position mode for all motors. Returns the bus."""
     bus = arm.motors
     if bus is None:
         raise RuntimeError(f"Motors for {arm} are not initialized.")
@@ -49,80 +33,67 @@ def reset_torque_and_set_mode(arm: Arm) -> None:
 
     all_motor_names = arm.motor_names
 
-    # Disable torque for all motors
-    disable_torque_values: Dict[str, int | float] = {name: 0 for name in all_motor_names}
-    bus.sync_write(STSControlTable.TORQUE_ENABLE, disable_torque_values)
+    # Disable torque
+    bus.sync_write(STSControlTable.TORQUE_ENABLE, {name: 0 for name in all_motor_names})
 
     # Set position mode (mode 0) for all motors
-    position_mode_values: Dict[str, int | float] = {name: 0 for name in all_motor_names}
-    bus.sync_write(STSControlTable.OPERATING_MODE, position_mode_values)
+    bus.sync_write(STSControlTable.OPERATING_MODE, {name: 0 for name in all_motor_names})
+
+    return bus
 
 
-def run_arm_calibration(arm: Arm, arm_type: str) -> Dict[str, Tuple[int, bool]]:
+def run_arm_calibration(arm: Arm, arm_type: str) -> Dict[str, MotorCalibration]:
     """
     Runs the interactive calibration procedure for a single SO-101 arm.
-    This function determines the homing offset and drive mode for each motor.
+
+    Procedure (matching lerobot):
+    1. Move arm to the middle of its range of motion → set homing offsets
+    2. Move all joints (except wrist_roll) through their full range → record min/max
+    3. wrist_roll gets hardcoded range [0, 4095]
     """
-    reset_torque_and_set_mode(arm)
-
-    if arm.motors is None:
-        raise RuntimeError(f"Motors for {arm_type} arm are not initialized.")
-
+    bus = _disable_torque_and_set_position_mode(arm)
     motor_names = arm.motor_names
-    resolutions = [arm.motors.motors[name].resolution for name in motor_names]
 
     print(f"\n>> Running calibration of the SO-101 {arm_type} arm...")
 
-    print("\n[Step 1/2] Move the arm to the ZERO position.")
-    print("  All joints should be at their neutral/zero angle.")
+    # --- Step 1: Set homing offsets (half-turn centering) ---
+    print("\n[Step 1/2] Move the arm to the MIDDLE of its range of motion.")
+    print("  Each joint should be approximately at the center of how far it can move.")
     input("Press Enter when ready...")
 
-    # --- Homing Offset Calculation (First Pass) ---
-    zero_pos_steps = convert_degrees_to_steps(ZERO_POSITION_DEGREE, resolutions)
+    homing_offsets = bus.set_half_turn_homings()
+    logger.info(f"Homing offsets: {homing_offsets}")
 
-    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
-    current_pos = np.array([pos_dict[name] for name in motor_names])
+    # --- Step 2: Record ranges of motion ---
+    print("\n[Step 2/2] Move all joints (except wrist_roll) through their full range of motion.")
+    print("  Slowly sweep each joint from one limit to the other.")
 
-    # Round to nearest quarter turn to reduce manual positioning errors
-    quarter_turn_steps = convert_degrees_to_steps(90, resolutions)
-    rounded_pos = np.round(current_pos.astype(float) / quarter_turn_steps) * quarter_turn_steps
+    unknown_range_motors = [name for name in motor_names if name != FULL_TURN_MOTOR]
+    range_mins, range_maxes = bus.record_ranges_of_motion(unknown_range_motors)
 
-    homing_offset = zero_pos_steps - rounded_pos.astype(int)
-
-    # --- Drive Mode Calculation ---
-    print("\n[Step 2/2] Move the arm to the ROTATED position.")
-    print("  Rotate each joint approximately +90 degrees from the zero position.")
-    input("Press Enter when ready...")
-
-    rotated_pos_steps = convert_degrees_to_steps(ROTATED_POSITION_DEGREE, resolutions)
-
-    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
-    current_pos = np.array([pos_dict[name] for name in motor_names])
-
-    # Apply preliminary offset and round
-    pos_with_offset = current_pos + homing_offset
-    rounded_pos = np.round(pos_with_offset.astype(float) / quarter_turn_steps) * quarter_turn_steps
-
-    # If the rounded position doesn't match the target, the drive mode is inverted
-    drive_mode = (rounded_pos != rotated_pos_steps).astype(np.int32)
-
-    # --- Homing Offset Refinement (Second Pass) ---
-    pos_dict = arm.motors.sync_read(STSControlTable.PRESENT_POSITION, motor_names)
-    current_pos = np.array([pos_dict[name] for name in motor_names])
-
-    pos_with_drive_mode = apply_drive_mode(current_pos, drive_mode)
-    rounded_pos = (
-        np.round(pos_with_drive_mode.astype(float) / quarter_turn_steps) * quarter_turn_steps
-    )
-
-    homing_offset = rotated_pos_steps - rounded_pos.astype(int)
+    # wrist_roll is a full-rotation joint
+    if FULL_TURN_MOTOR in motor_names:
+        resolution = bus.motors[FULL_TURN_MOTOR].resolution
+        range_mins[FULL_TURN_MOTOR] = 0
+        range_maxes[FULL_TURN_MOTOR] = resolution - 1  # 4095
 
     print("\nCalibration for this arm is complete. Please move it to a safe rest position.")
     input("Press Enter to continue...")
 
-    # --- Format and Return Calibration Data ---
-    calibration_data = {
-        name: (int(homing_offset[i]), bool(drive_mode[i])) for i, name in enumerate(motor_names)
-    }
+    # --- Build calibration data ---
+    calibration: Dict[str, MotorCalibration] = {}
+    for name in motor_names:
+        motor = bus.motors[name]
+        calibration[name] = MotorCalibration(
+            id=motor.id,
+            drive_mode=0,
+            homing_offset=homing_offsets[name],
+            range_min=range_mins[name],
+            range_max=range_maxes[name],
+        )
 
-    return calibration_data
+    # Write calibration to motor EEPROM
+    bus.set_calibration(calibration)
+    bus.write_calibration_to_motors()
+
+    return calibration

--- a/src/robopy/robots/so101/so101_follower.py
+++ b/src/robopy/robots/so101/so101_follower.py
@@ -1,7 +1,7 @@
 import logging
 
 from robopy.config.robot_config.so101_config import So101Config
-from robopy.motor.feetech_bus import FeetechBus, FeetechMotor
+from robopy.motor.feetech_bus import FeetechBus, FeetechMotor, NormMode
 from robopy.motor.feetech_control_table import STSControlTable
 from robopy.robots.common.arm import Arm
 
@@ -27,7 +27,7 @@ class So101Follower(Arm):
                 "elbow_flex": FeetechMotor(3, "elbow_flex", "sts3215"),
                 "wrist_flex": FeetechMotor(4, "wrist_flex", "sts3215"),
                 "wrist_roll": FeetechMotor(5, "wrist_roll", "sts3215"),
-                "gripper": FeetechMotor(6, "gripper", "sts3215"),
+                "gripper": FeetechMotor(6, "gripper", "sts3215", NormMode.RANGE_0_100),
             },
         )
         self._is_connected = False

--- a/src/robopy/robots/so101/so101_follower.py
+++ b/src/robopy/robots/so101/so101_follower.py
@@ -1,0 +1,101 @@
+import logging
+
+from robopy.config.robot_config.so101_config import So101Config
+from robopy.motor.feetech_bus import FeetechBus, FeetechMotor
+from robopy.motor.feetech_control_table import STSControlTable
+from robopy.robots.common.arm import Arm
+
+logger = logging.getLogger(__name__)
+
+
+class So101Follower(Arm):
+    """Class representing the SO-101 Follower arm with Feetech STS3215 motors.
+
+    The follower arm has 6 joints (motor IDs 1-6):
+    shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll, gripper.
+    """
+
+    def __init__(self, config: So101Config) -> None:
+        self.config = config
+        self._port = config.follower_port
+
+        self._motors = FeetechBus(
+            port=self._port,
+            motors={
+                "shoulder_pan": FeetechMotor(1, "shoulder_pan", "sts3215"),
+                "shoulder_lift": FeetechMotor(2, "shoulder_lift", "sts3215"),
+                "elbow_flex": FeetechMotor(3, "elbow_flex", "sts3215"),
+                "wrist_flex": FeetechMotor(4, "wrist_flex", "sts3215"),
+                "wrist_roll": FeetechMotor(5, "wrist_roll", "sts3215"),
+                "gripper": FeetechMotor(6, "gripper", "sts3215"),
+            },
+        )
+        self._is_connected = False
+
+    @property
+    def port(self) -> str:
+        return self._port
+
+    @property
+    def motors(self) -> FeetechBus:
+        return self._motors
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    def torque_enable(self) -> None:
+        self._motors.sync_write(
+            STSControlTable.TORQUE_ENABLE, {name: 1 for name in self.motor_names}
+        )
+
+    def torque_disable(self) -> None:
+        self._motors.sync_write(
+            STSControlTable.TORQUE_ENABLE, {name: 0 for name in self.motor_names}
+        )
+
+    def connect(self) -> None:
+        if self._is_connected:
+            logger.info("Already connected to the SO-101 Follower arm.")
+            return
+        try:
+            self._motors.open()
+            self._is_connected = True
+            logger.info("Connected to the SO-101 Follower arm.")
+        except Exception as e:
+            logger.error(f"Failed to connect to the SO-101 Follower arm: {e}")
+            raise ConnectionError(f"Failed to connect to the SO-101 Follower arm: {e}")
+
+        # Configure PID gains for stable position control
+        # Lower P to avoid shakiness, matching lerobot's defaults
+        for motor_name in self.motor_names:
+            self._motors.write(STSControlTable.P_COEFFICIENT, motor_name, 16)
+            self._motors.write(STSControlTable.I_COEFFICIENT, motor_name, 0)
+            self._motors.write(STSControlTable.D_COEFFICIENT, motor_name, 32)
+
+        # Limit gripper torque and current to protect objects
+        self._motors.write(STSControlTable.MAX_TORQUE_LIMIT, "gripper", 500)
+        self._motors.write(STSControlTable.PROTECTION_CURRENT, "gripper", 250)
+        self._motors.write(STSControlTable.OVERLOAD_TORQUE, "gripper", 25)
+
+    def disconnect(self) -> None:
+        self.torque_disable()
+
+        if not self._is_connected:
+            logger.info("Not connected to the SO-101 Follower arm.")
+            return
+        try:
+            self._motors.close()
+            self._is_connected = False
+            logger.info("Disconnected from the SO-101 Follower arm.")
+        except Exception as e:
+            logger.error(f"Failed to disconnect from the SO-101 Follower arm: {e}")
+            raise ConnectionError(f"Failed to disconnect from the SO-101 Follower arm: {e}")
+
+    @property
+    def motor_names(self) -> list[str]:
+        return list(self._motors.motors.keys())
+
+    @property
+    def motor_models(self) -> list[str]:
+        return [motor.model_name for motor in self._motors.motors.values()]

--- a/src/robopy/robots/so101/so101_leader.py
+++ b/src/robopy/robots/so101/so101_leader.py
@@ -52,8 +52,9 @@ class So101Leader(Arm):
         if self._motors is None:
             logger.warning("Leader motors are not initialized. Cannot enable torque.")
             return
-        # Enable torque only on gripper for leader (to provide resistance)
-        self._motors.write(STSControlTable.TORQUE_ENABLE, "gripper", 1)
+        # Leader arm should have torque disabled to allow free movement during teleoperation
+        # No torque is enabled for any motors including gripper
+        logger.debug("Leader arm torque_enable called, but keeping all motors free to move.")
 
     def torque_disable(self) -> None:
         if self._motors is None:

--- a/src/robopy/robots/so101/so101_leader.py
+++ b/src/robopy/robots/so101/so101_leader.py
@@ -1,7 +1,7 @@
 import logging
 
 from robopy.config.robot_config.so101_config import So101Config
-from robopy.motor.feetech_bus import FeetechBus, FeetechMotor
+from robopy.motor.feetech_bus import FeetechBus, FeetechMotor, NormMode
 from robopy.motor.feetech_control_table import STSControlTable
 from robopy.robots.common.arm import Arm
 
@@ -31,7 +31,7 @@ class So101Leader(Arm):
                     "elbow_flex": FeetechMotor(3, "elbow_flex", "sts3215"),
                     "wrist_flex": FeetechMotor(4, "wrist_flex", "sts3215"),
                     "wrist_roll": FeetechMotor(5, "wrist_roll", "sts3215"),
-                    "gripper": FeetechMotor(6, "gripper", "sts3215"),
+                    "gripper": FeetechMotor(6, "gripper", "sts3215", NormMode.RANGE_0_100),
                 },
             )
         self._is_connected = False

--- a/src/robopy/robots/so101/so101_leader.py
+++ b/src/robopy/robots/so101/so101_leader.py
@@ -1,0 +1,104 @@
+import logging
+
+from robopy.config.robot_config.so101_config import So101Config
+from robopy.motor.feetech_bus import FeetechBus, FeetechMotor
+from robopy.motor.feetech_control_table import STSControlTable
+from robopy.robots.common.arm import Arm
+
+logger = logging.getLogger(__name__)
+
+
+class So101Leader(Arm):
+    """Class representing the SO-101 Leader arm with Feetech STS3215 motors.
+
+    The leader arm has 6 joints (motor IDs 1-6):
+    shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll, gripper.
+    """
+
+    def __init__(self, config: So101Config) -> None:
+        self.config = config
+        self._port = config.leader_port
+
+        if self._port is None:
+            logger.warning("Leader port is not specified. Leader arm will not be initialized.")
+            self._motors: FeetechBus | None = None
+        else:
+            self._motors = FeetechBus(
+                port=self._port,
+                motors={
+                    "shoulder_pan": FeetechMotor(1, "shoulder_pan", "sts3215"),
+                    "shoulder_lift": FeetechMotor(2, "shoulder_lift", "sts3215"),
+                    "elbow_flex": FeetechMotor(3, "elbow_flex", "sts3215"),
+                    "wrist_flex": FeetechMotor(4, "wrist_flex", "sts3215"),
+                    "wrist_roll": FeetechMotor(5, "wrist_roll", "sts3215"),
+                    "gripper": FeetechMotor(6, "gripper", "sts3215"),
+                },
+            )
+        self._is_connected = False
+
+    @property
+    def port(self) -> str | None:
+        return self._port
+
+    @property
+    def motors(self) -> FeetechBus | None:
+        return self._motors
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    def torque_enable(self) -> None:
+        if self._motors is None:
+            logger.warning("Leader motors are not initialized. Cannot enable torque.")
+            return
+        # Enable torque only on gripper for leader (to provide resistance)
+        self._motors.write(STSControlTable.TORQUE_ENABLE, "gripper", 1)
+
+    def torque_disable(self) -> None:
+        if self._motors is None:
+            return
+        self._motors.torque_disabled()
+
+    def connect(self) -> None:
+        if self._port is None or self._motors is None:
+            logger.info("Leader port is not specified. Skipping leader arm connection.")
+            return
+        if self._is_connected:
+            logger.info("Already connected to the SO-101 Leader arm.")
+            return
+        try:
+            self._motors.open()
+            self._is_connected = True
+            logger.info("Connected to the SO-101 Leader arm.")
+        except Exception as e:
+            logger.error(f"Failed to connect to the SO-101 Leader arm: {e}")
+            raise ConnectionError(f"Failed to connect to the SO-101 Leader arm: {e}")
+
+    def disconnect(self) -> None:
+        if self._motors is None:
+            return
+        self.torque_disable()
+
+        if not self._is_connected:
+            logger.info("Not connected to the SO-101 Leader arm.")
+            return
+        try:
+            self._motors.close()
+            self._is_connected = False
+            logger.info("Disconnected from the SO-101 Leader arm.")
+        except Exception as e:
+            logger.error(f"Failed to disconnect from the SO-101 Leader arm: {e}")
+            raise ConnectionError(f"Failed to disconnect from the SO-101 Leader arm: {e}")
+
+    @property
+    def motor_names(self) -> list[str]:
+        if self._motors is None:
+            return []
+        return list(self._motors.motors.keys())
+
+    @property
+    def motor_models(self) -> list[str]:
+        if self._motors is None:
+            return []
+        return [motor.model_name for motor in self._motors.motors.values()]

--- a/src/robopy/robots/so101/so101_leader.py
+++ b/src/robopy/robots/so101/so101_leader.py
@@ -2,7 +2,6 @@ import logging
 
 from robopy.config.robot_config.so101_config import So101Config
 from robopy.motor.feetech_bus import FeetechBus, FeetechMotor, NormMode
-from robopy.motor.feetech_control_table import STSControlTable
 from robopy.robots.common.arm import Arm
 
 logger = logging.getLogger(__name__)

--- a/src/robopy/robots/so101/so101_pair_sys.py
+++ b/src/robopy/robots/so101/so101_pair_sys.py
@@ -1,0 +1,264 @@
+# robopy/robots/so101/so101_pair_sys.py
+
+import logging
+import os
+import pickle
+import time
+from typing import Any, Dict, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from robopy.config.robot_config.so101_config import SO101_MOTOR_MAPPING, So101Config
+from robopy.motor.feetech_control_table import STSControlTable
+from robopy.robots.so101.calibration import run_arm_calibration
+
+from ..common.robot import Robot
+from .so101_follower import So101Follower
+from .so101_leader import So101Leader
+
+logger = logging.getLogger(__name__)
+
+
+class So101PairSys(Robot):
+    """Class representing a pair of SO-101 robotic arms: Leader and Follower."""
+
+    def __init__(self, cfg: So101Config) -> None:
+        self._leader: So101Leader | None
+        if cfg.leader_port is not None:
+            self._leader = So101Leader(cfg)
+        else:
+            self._leader = None
+            logger.info("Leader port is not specified. Leader arm will not be available.")
+        self._follower = So101Follower(cfg)
+
+        self.calibration_path = cfg.calibration_path
+        self._is_connected = False
+
+        self._motor_mapping = SO101_MOTOR_MAPPING
+
+    def connect(self) -> None:
+        """Connects to all devices and handles calibration."""
+        if self._is_connected:
+            logger.info("So101PairSys is already connected.")
+            return
+
+        try:
+            if self._leader is not None:
+                logger.info("Connecting to SO-101 leader arm...")
+                self._leader.connect()
+            else:
+                logger.info("Leader arm is not available. Skipping leader connection.")
+            logger.info("Connecting to SO-101 follower arm...")
+            self._follower.connect()
+
+            # --- Calibration Logic ---
+            try:
+                if os.path.exists(self.calibration_path):
+                    logger.info(f"Loading calibration from '{self.calibration_path}'...")
+                    with open(self.calibration_path, "rb") as f:
+                        calibration = pickle.load(f)
+                else:
+                    logger.info("Calibration file not found. Starting new calibration procedure.")
+                    calibration = self.run_calibration()
+
+                    os.makedirs(os.path.dirname(self.calibration_path), exist_ok=True)
+                    logger.info(f"Saving calibration to '{self.calibration_path}'...")
+                    with open(self.calibration_path, "wb") as f:
+                        pickle.dump(calibration, f)
+            except (OSError, IOError, PermissionError) as e:
+                logger.error(f"File operation error: {e}")
+                raise ConnectionError(f"Calibration file error: {e}")
+            except (pickle.PickleError, EOFError) as e:
+                logger.error(f"Calibration data corrupted: {e}")
+                raise ConnectionError(f"Calibration data error: {e}")
+
+            # Apply calibration to each arm
+            if self._leader is not None and self._leader.motors is not None:
+                self._leader.motors.set_calibration(calibration["leader"])
+            self._follower.motors.set_calibration(calibration["follower"])
+            logger.info("Calibration successfully applied to both arms.")
+
+            self.follower.torque_enable()
+            if self.leader is not None:
+                self.leader.torque_enable()
+
+            self._is_connected = True
+            logger.info("Connected to So101PairSys successfully")
+
+        except ConnectionError:
+            self.disconnect()
+            raise
+        except (OSError, TimeoutError, RuntimeError) as e:
+            logger.error(f"Hardware connection error: {e}")
+            self.disconnect()
+            raise ConnectionError(f"Connection failed due to hardware error: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error during connection: {e}")
+            self.disconnect()
+            raise ConnectionError(f"Connection failed due to unexpected error: {e}")
+
+    def run_calibration(self) -> Dict[str, Dict[str, Tuple[int, bool]]]:
+        """Orchestrates the calibration process for both arms."""
+        all_calibration_data = {}
+
+        if self._leader is not None:
+            leader_calib = run_arm_calibration(self._leader, arm_type="leader")
+            all_calibration_data["leader"] = leader_calib
+        else:
+            all_calibration_data["leader"] = {}
+
+        follower_calib = run_arm_calibration(self._follower, arm_type="follower")
+        all_calibration_data["follower"] = follower_calib
+
+        logger.info("Both SO-101 arms have been calibrated.")
+        return all_calibration_data
+
+    def disconnect(self) -> None:
+        """Disconnects from all devices."""
+        if self._is_connected:
+            logger.info("Disconnecting So101PairSys...")
+            if self._leader is not None:
+                self._leader.disconnect()
+            self._follower.disconnect()
+            self._is_connected = False
+            logger.info("Disconnected from So101PairSys")
+
+    def get_observation(
+        self, leader_obs: Dict[str, NDArray[np.float32]] | None = None
+    ) -> Dict[str, NDArray[np.float32]]:
+        """Gets the current observation from both arms."""
+        if not self._is_connected:
+            raise ConnectionError("So101PairSys is not connected. Call connect() first.")
+
+        follower_motor_names = list(self._follower.motors.motors.keys())
+
+        if self._leader is not None and self._leader.motors is not None:
+            leader_motor_names = list(self._leader.motors.motors.keys())
+            if leader_obs is None:
+                leader_obs = self._leader.motors.sync_read(
+                    STSControlTable.PRESENT_POSITION, leader_motor_names
+                )
+            leader_obs_array = np.array(list(leader_obs.values()), dtype=np.float32)
+        else:
+            leader_obs_array = np.array([], dtype=np.float32)
+            logger.debug("Leader arm is not available. Returning empty leader observation.")
+
+        follower_obs = self._follower.motors.sync_read(
+            STSControlTable.PRESENT_POSITION, follower_motor_names
+        )
+
+        follower_obs_array = np.array(list(follower_obs.values()), dtype=np.float32)
+        logger.debug(f"Leader positions: {leader_obs_array}")
+        logger.debug(f"Follower positions: {follower_obs_array}")
+
+        return {
+            "leader": leader_obs_array,
+            "follower": follower_obs_array,
+        }
+
+    def teleoperate(self) -> None:
+        """Teleoperation: Leader controls the Follower arm movements."""
+        if not self._is_connected:
+            raise ConnectionError("So101PairSys is not connected. Call connect() first.")
+
+        if self._leader is None or self._leader.motors is None:
+            raise ConnectionError("Leader arm is not available. Cannot start teleoperation.")
+
+        logger.info("Starting SO-101 teleoperation. Leader will control follower.")
+        logger.info("Press Ctrl+C to stop teleoperation.")
+
+        try:
+            while True:
+                leader_motor_names = list(self._leader.motors.motors.keys())
+                leader_positions = self._leader.motors.sync_read(
+                    STSControlTable.PRESENT_POSITION, leader_motor_names
+                )
+
+                follower_goals: Dict[str, Any] = {}
+                for leader_motor, leader_pos in leader_positions.items():
+                    if leader_motor in self._motor_mapping:
+                        follower_motor = self._motor_mapping[leader_motor]
+                        if follower_motor in self._follower.motors.motors:
+                            follower_goals[follower_motor] = leader_pos
+                        else:
+                            logger.warning(f"Follower motor '{follower_motor}' not found")
+                    else:
+                        logger.warning(f"No mapping found for leader motor '{leader_motor}'")
+
+                if follower_goals:
+                    self._follower.motors.sync_write(
+                        STSControlTable.GOAL_POSITION, follower_goals
+                    )
+
+                time.sleep(0.01)  # 100Hz update rate
+
+        except KeyboardInterrupt:
+            logger.info("Teleoperation stopped by user.")
+        except Exception as e:
+            logger.error(f"Error during teleoperation: {e}")
+            raise
+
+    def teleope_step(self, if_record: bool = True) -> None | Dict[str, NDArray[np.float32]]:
+        """Teleoperation step: Leader controls the Follower arm movements."""
+        if not self._is_connected:
+            raise ConnectionError("So101PairSys is not connected. Call connect() first.")
+
+        if self._leader is None or self._leader.motors is None:
+            logger.warning("Leader arm is not available. Cannot perform teleoperation step.")
+            if if_record:
+                return self.get_observation(leader_obs=None)
+            return None
+
+        leader_motor_names = list(self._leader.motors.motors.keys())
+        leader_positions = self._leader.motors.sync_read(
+            STSControlTable.PRESENT_POSITION, leader_motor_names
+        )
+
+        follower_goals = {}
+        for leader_motor, leader_pos in leader_positions.items():
+            if leader_motor in self._motor_mapping:
+                follower_motor = self._motor_mapping[leader_motor]
+                if follower_motor in self._follower.motors.motors:
+                    follower_goals[follower_motor] = leader_pos
+                else:
+                    logger.warning(f"Follower motor '{follower_motor}' not found")
+            else:
+                logger.warning(f"No mapping found for leader motor '{leader_motor}'")
+
+        if follower_goals:
+            self._follower.motors.sync_write(STSControlTable.GOAL_POSITION, follower_goals)
+
+        if if_record:
+            return self.get_observation(leader_obs=leader_positions)
+        return None
+
+    def get_leader_action(self) -> dict[str, NDArray[np.float32]]:
+        """Get the current action (positions) from the leader arm."""
+        if not self._is_connected:
+            raise ConnectionError("So101PairSys is not connected. Call connect() first.")
+
+        if self._leader is None or self._leader.motors is None:
+            logger.warning("Leader arm is not available. Returning empty action.")
+            return {}
+
+        leader_motor_names = list(self._leader.motors.motors.keys())
+        leader_positions = self._leader.motors.sync_read(
+            STSControlTable.PRESENT_POSITION, leader_motor_names
+        )
+        return leader_positions
+
+    def send_follower_action(self, action: dict[str, float]) -> None:
+        """Send action to the follower arm only."""
+        if not self._is_connected:
+            raise ConnectionError("So101PairSys is not connected. Call connect() first.")
+
+        self._follower.motors.sync_write(STSControlTable.GOAL_POSITION, action)
+
+    @property
+    def leader(self) -> So101Leader | None:
+        return self._leader
+
+    @property
+    def follower(self) -> So101Follower:
+        return self._follower

--- a/src/robopy/robots/so101/so101_pair_sys.py
+++ b/src/robopy/robots/so101/so101_pair_sys.py
@@ -187,9 +187,7 @@ class So101PairSys(Robot):
                         logger.warning(f"No mapping found for leader motor '{leader_motor}'")
 
                 if follower_goals:
-                    self._follower.motors.sync_write(
-                        STSControlTable.GOAL_POSITION, follower_goals
-                    )
+                    self._follower.motors.sync_write(STSControlTable.GOAL_POSITION, follower_goals)
 
                 time.sleep(0.01)  # 100Hz update rate
 

--- a/src/robopy/robots/so101/so101_robot.py
+++ b/src/robopy/robots/so101/so101_robot.py
@@ -286,9 +286,7 @@ class So101Robot(ComposedRobot[So101PairSys, Sensors, So101Obs]):
         max_processing_time_ms: float = 40,
     ) -> So101Obs:
         """Placeholder for future fixed-leader recording support."""
-        raise NotImplementedError(
-            "record_with_fixed_leader is not implemented for So101Robot yet."
-        )
+        raise NotImplementedError("record_with_fixed_leader is not implemented for So101Robot yet.")
 
     def get_observation(self) -> So101Obs:
         if not self.is_connected:
@@ -498,7 +496,7 @@ class So101Robot(ComposedRobot[So101PairSys, Sensors, So101Obs]):
             obs = self.get_arm_observation()
             current_joint_angles_deg = obs.follower
 
-        result = self.inverse_kinematics(ee, current_joint_angles_deg)
+        result = self.inverse_kinematics(ee.astype(np.float32), current_joint_angles_deg)
 
         if not result.success:
             logger.warning(

--- a/src/robopy/robots/so101/so101_robot.py
+++ b/src/robopy/robots/so101/so101_robot.py
@@ -1,0 +1,491 @@
+import queue
+import threading
+import time
+from collections import defaultdict
+from logging import getLogger
+from typing import DefaultDict, Dict, List
+
+import numpy as np
+from numpy.typing import NDArray
+from rich.progress import Progress
+
+from robopy.config.robot_config.so101_config import (
+    SO101_MOTOR_MAPPING,
+    So101Config,
+    So101SensorConfig,
+)
+from robopy.config.sensor_config.sensors import Sensors
+from robopy.config.sensor_config.visual_config.camera_config import (
+    RealsenseCameraConfig,
+    WebCameraConfig,
+)
+from robopy.robots.common.composed import ComposedRobot
+from robopy.sensors.visual.realsense_camera import RealsenseCamera
+from robopy.sensors.visual.web_camera import WebCamera
+from robopy.utils.worker.so101_save_worker import So101ArmObs, So101Obs
+
+from .so101_pair_sys import So101PairSys
+
+logger = getLogger(__name__)
+
+
+class So101Robot(ComposedRobot[So101PairSys, Sensors, So101Obs]):
+    def __init__(self, cfg: So101Config) -> None:
+        super().__init__()
+        self.config = self._init_config(cfg)
+        self._sensor_configs = self.config.sensors
+        self._robot_system = So101PairSys(self.config)
+        self._sensors = self._init_sensors()
+        self._cameras: List[WebCamera | RealsenseCamera] = list(self._sensors.cameras or [])
+
+    def connect(self) -> None:
+        try:
+            self._robot_system.connect()
+        except Exception as exc:
+            logger.error("Failed to connect SO-101 robot system: %s", exc)
+            self._robot_system.disconnect()
+            raise
+
+        for cam in self._cameras:
+            if cam.is_connected:
+                continue
+            try:
+                cam.connect()
+            except Exception as exc:
+                logger.error("Failed to connect camera %s: %s", cam.name, exc)
+                cam.disconnect()
+                raise
+
+    def disconnect(self) -> None:
+        self._robot_system.disconnect()
+        for cam in self._cameras:
+            if cam.is_connected:
+                cam.disconnect()
+
+    def teleoperation(self, max_seconds: float | None = None) -> None:
+        """Start teleoperation mode where leader controls follower."""
+        if not self.is_connected:
+            raise ConnectionError("So101Robot is not connected. Call connect() first.")
+
+        if self._robot_system.leader is None:
+            raise ConnectionError("Leader arm is not available. Cannot start teleoperation.")
+
+        if max_seconds is not None and max_seconds > 0:
+            end_time = time.perf_counter() + max_seconds
+            while time.perf_counter() < end_time:
+                self._teleoperate_step(record=False)
+                time.sleep(0.01)
+            return
+
+        self._robot_system.teleoperate()
+
+    def record(self, max_frame: int, fps: int = 5) -> So101Obs:
+        if max_frame <= 0:
+            raise ValueError("max_frame must be greater than 0.")
+        if fps <= 0:
+            raise ValueError("fps must be greater than 0.")
+
+        if not self.is_connected:
+            self.connect()
+
+        leader_obs: List[NDArray[np.float32]] = []
+        follower_obs: List[NDArray[np.float32]] = []
+        camera_obs: DefaultDict[str, List[NDArray[np.float32] | NDArray[np.uint8] | None]] = (
+            defaultdict(list)
+        )
+
+        interval = 1.0 / fps
+        frame_start = time.perf_counter()
+
+        try:
+            for _ in range(max_frame):
+                arm_obs = self._teleoperate_step(record=True)
+                if arm_obs is None:
+                    continue
+
+                leader_obs.append(arm_obs.leader)
+                follower_obs.append(arm_obs.follower)
+
+                sensor_data = self.sensors_observation()
+                for cam_name, frame in sensor_data.items():
+                    camera_obs[cam_name].append(frame)
+
+                elapsed = time.perf_counter() - frame_start
+                sleep_time = interval - elapsed
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+                frame_start = time.perf_counter()
+
+        except KeyboardInterrupt:
+            logger.info("Recording interrupted by user.")
+            raise
+        except Exception as exc:
+            logger.error("An error occurred during recording: %s", exc)
+            raise
+
+        leader_arr = np.asarray(leader_obs, dtype=np.float32)
+        follower_arr = np.asarray(follower_obs, dtype=np.float32)
+        arms = So101ArmObs(leader=leader_arr, follower=follower_arr)
+
+        camera_obs_np: Dict[str, NDArray[np.uint8] | NDArray[np.float32] | None] = {}
+        for cam_name, frames in camera_obs.items():
+            if frames and all(frame is not None for frame in frames):
+                camera_obs_np[cam_name] = np.asarray(frames)
+            else:
+                camera_obs_np[cam_name] = None
+
+        return So101Obs(arms=arms, cameras=camera_obs_np)
+
+    def record_parallel(
+        self,
+        max_frame: int,
+        fps: int = 20,
+        teleop_hz: int = 25,
+        max_processing_time_ms: float | None = None,
+        is_async: bool = True,
+    ) -> So101Obs:
+        if max_frame <= 0:
+            raise ValueError("max_frame must be greater than 0.")
+        if fps <= 0:
+            raise ValueError("fps must be greater than 0.")
+
+        if not self.is_connected:
+            self.connect()
+
+        if max_processing_time_ms is None:
+            max_processing_time_ms = 1000.0 / fps * 0.9
+
+        arm_obs_queue: queue.Queue[So101ArmObs] = queue.Queue(maxsize=teleop_hz * 2)
+        stop_event = threading.Event()
+
+        def teleop_worker() -> None:
+            interval = 1.0 / teleop_hz
+            while not stop_event.is_set():
+                start_time = time.perf_counter()
+                arm_obs = self._teleoperate_step(record=True)
+                if arm_obs is not None:
+                    try:
+                        arm_obs_queue.put(arm_obs, timeout=interval)
+                    except queue.Full:
+                        pass
+
+                elapsed = time.perf_counter() - start_time
+                time.sleep(max(0.0, interval - elapsed))
+
+        teleop_thread = threading.Thread(target=teleop_worker, daemon=True)
+        teleop_thread.start()
+
+        leader_obs: List[NDArray[np.float32]] = []
+        follower_obs: List[NDArray[np.float32]] = []
+        camera_obs: DefaultDict[str, List[NDArray[np.float32] | NDArray[np.uint8] | None]] = (
+            defaultdict(list)
+        )
+
+        get_obs_interval = 1.0 / fps
+        max_processing_time = max_processing_time_ms / 1000.0
+        frame_count = 0
+        skipped_frames = 0
+        total_processing_time = 0.0
+
+        logger.info(
+            "Starting SO-101 parallel recording: frames=%s, fps=%s, teleop_hz=%s",
+            max_frame,
+            fps,
+            teleop_hz,
+        )
+
+        try:
+            with Progress() as progress:
+                task = progress.add_task("[green]Recording SO-101 Robot...", total=max_frame)
+                while frame_count < max_frame:
+                    frame_start = time.perf_counter()
+
+                    try:
+                        arm_obs = arm_obs_queue.get(timeout=get_obs_interval)
+                        while not arm_obs_queue.empty():
+                            arm_obs = arm_obs_queue.get_nowait()
+                    except queue.Empty:
+                        logger.warning("No arm observation available in time.")
+                        continue
+
+                    sensor_data = self.sensors_observation(
+                        timeout_ms=max_processing_time_ms / 2.0, async_mode=is_async
+                    )
+
+                    leader_obs.append(arm_obs.leader)
+                    follower_obs.append(arm_obs.follower)
+
+                    for cam_name, frame in sensor_data.items():
+                        camera_obs[cam_name].append(frame)
+
+                    frame_count += 1
+                    progress.update(task, advance=1)
+                    processing_time = time.perf_counter() - frame_start
+                    total_processing_time += processing_time
+
+                    if processing_time > max_processing_time:
+                        skipped_frames += 1
+                        logger.warning(
+                            "Frame %s took %.1f ms (> %.1f ms), skipping sleep",
+                            frame_count,
+                            processing_time * 1000.0,
+                            max_processing_time_ms,
+                        )
+                        continue
+
+                    sleep_time = max(0.0, get_obs_interval - processing_time)
+                    if sleep_time > 0:
+                        time.sleep(sleep_time)
+                progress.remove_task(task)
+
+        except KeyboardInterrupt:
+            logger.info("Recording interrupted by user.")
+            raise
+        except Exception as exc:
+            logger.error("An error occurred during parallel recording: %s", exc)
+            raise
+        finally:
+            stop_event.set()
+            teleop_thread.join(timeout=1.0)
+
+        if frame_count == 0:
+            raise RuntimeError("No frames captured during parallel recording.")
+
+        avg_processing_time = total_processing_time / frame_count * 1000.0
+        logger.info(
+            "SO-101 parallel recording completed: frames=%s, skipped=%s, avg_proc=%.1f ms",
+            frame_count,
+            skipped_frames,
+            avg_processing_time,
+        )
+
+        leader_arr = np.asarray(leader_obs, dtype=np.float32)
+        follower_arr = np.asarray(follower_obs, dtype=np.float32)
+        arms = So101ArmObs(leader=leader_arr, follower=follower_arr)
+
+        camera_obs_np: Dict[str, NDArray[np.uint8] | NDArray[np.float32] | None] = {}
+        for cam_name, frames in camera_obs.items():
+            if frames and all(frame is not None for frame in frames):
+                camera_obs_np[cam_name] = np.asarray(frames)
+            else:
+                camera_obs_np[cam_name] = None
+
+        return So101Obs(arms=arms, cameras=camera_obs_np)
+
+    def record_with_fixed_leader(
+        self,
+        max_frame: int,
+        leader_action: NDArray[np.float32],
+        fps: int = 20,
+        teleop_hz: int = 100,
+        max_processing_time_ms: float = 40,
+    ) -> So101Obs:
+        """Placeholder for future fixed-leader recording support."""
+        raise NotImplementedError(
+            "record_with_fixed_leader is not implemented for So101Robot yet."
+        )
+
+    def get_observation(self) -> So101Obs:
+        if not self.is_connected:
+            raise ConnectionError("So101Robot is not connected. Call connect() first.")
+
+        arm_obs_dict = self._robot_system.get_observation()
+        arms = self._to_arm_obs(arm_obs_dict)
+        camera_data = self.sensors_observation(async_mode=False)
+
+        return So101Obs(arms=arms, cameras=camera_data)
+
+    def get_arm_observation(self) -> So101ArmObs:
+        if not self.is_connected:
+            raise ConnectionError("So101Robot is not connected. Call connect() first.")
+
+        arm_obs_dict = self._robot_system.get_observation()
+        return self._to_arm_obs(arm_obs_dict)
+
+    def sensors_observation(
+        self, *, async_mode: bool = True, timeout_ms: float = 16.0
+    ) -> Dict[str, NDArray[np.float32] | NDArray[np.uint8] | None]:
+        if not self.is_connected:
+            raise ConnectionError("So101Robot is not connected. Call connect() first.")
+
+        return self._capture_camera_data(async_mode=async_mode, timeout_ms=timeout_ms)
+
+    def send(
+        self,
+        max_frame: int,
+        fps: int,
+        leader_action: NDArray[np.float32],
+        teleop_hz: int = 100,
+    ) -> None:
+        if not self.is_connected:
+            raise ConnectionError("So101Robot is not connected. Call connect() first.")
+
+        if max_frame <= 0:
+            raise ValueError("max_frame must be greater than 0.")
+        if leader_action.shape[0] != max_frame:
+            raise ValueError("Length of leader_action must match max_frame.")
+        if leader_action.ndim != 2:
+            raise ValueError("leader_action must be a 2D array.")
+
+        if self._robot_system.leader is not None and self._robot_system.leader.motors is not None:
+            leader_motor_names = list(self._robot_system.leader.motors.motors.keys())
+        else:
+            leader_motor_names = list(SO101_MOTOR_MAPPING.keys())
+
+        if leader_action.shape[1] != len(leader_motor_names):
+            raise ValueError(
+                f"leader_action must be of shape ({max_frame}, {len(leader_motor_names)})."
+            )
+
+        interval = 1.0 / teleop_hz
+        total_time = (max_frame - 1) / fps
+        start_time = time.perf_counter()
+        sent_count = 0
+
+        try:
+            while True:
+                now = time.perf_counter()
+                t = now - start_time
+                if t > total_time:
+                    break
+
+                idx_float = t * fps
+                idx0 = int(np.floor(idx_float))
+                idx1 = min(idx0 + 1, max_frame - 1)
+                alpha = idx_float - idx0
+
+                action = (1 - alpha) * leader_action[idx0] + alpha * leader_action[idx1]
+                self.send_frame_action(action)
+                sent_count += 1
+
+                next_time = start_time + sent_count * interval
+                while time.perf_counter() < next_time:
+                    pass
+
+            self.send_frame_action(leader_action[-1])
+
+        except KeyboardInterrupt:
+            logger.info("Send interrupted by user.")
+            self._robot_system.disconnect()
+        except Exception as exc:
+            logger.error("An error occurred during send: %s", exc)
+            raise
+
+    def send_frame_action(self, leader_action: NDArray[np.float32]) -> None:
+        follower_goals: Dict[str, float] = {}
+
+        if self._robot_system.leader is not None and self._robot_system.leader.motors is not None:
+            leader_motor_names = list(self._robot_system.leader.motors.motors.keys())
+        else:
+            leader_motor_names = list(SO101_MOTOR_MAPPING.keys())
+
+        if len(leader_action) != len(leader_motor_names):
+            raise ValueError(
+                f"Leader action length {len(leader_action)} does not match "
+                f"number of leader motors {len(leader_motor_names)}"
+            )
+
+        for i, motor_name in enumerate(leader_motor_names):
+            follower_name = SO101_MOTOR_MAPPING.get(motor_name)
+            if follower_name is not None:
+                follower_goals[follower_name] = float(leader_action[i])
+
+        self._robot_system.send_follower_action(follower_goals)
+
+    def _init_config(self, cfg: So101Config) -> So101Config:
+        if cfg.sensors is None:
+            cfg.sensors = So101SensorConfig()
+        return cfg
+
+    def _init_sensors(self) -> Sensors:
+        cameras: List[WebCamera | RealsenseCamera] = []
+        index = 0
+        for name, cam_cfg in self.config.sensors.cameras.items():
+            cam: WebCamera | RealsenseCamera
+            if isinstance(cam_cfg, WebCameraConfig):
+                cam = WebCamera(index, name, cam_cfg)
+            elif isinstance(cam_cfg, RealsenseCameraConfig):
+                cam = RealsenseCamera(cam_cfg)
+            else:
+                raise ValueError(f"Unsupported camera config type: {type(cam_cfg)}")
+            cameras.append(cam)
+            index += 1
+        return Sensors(cameras=cameras, tactile=None)
+
+    @property
+    def sensor_configs(self) -> So101SensorConfig:
+        return self._sensor_configs
+
+    @property
+    def is_connected(self) -> bool:
+        return getattr(self._robot_system, "_is_connected", False)
+
+    @property
+    def sensors(self) -> Sensors:
+        return self._sensors
+
+    @property
+    def robot_system(self) -> So101PairSys:
+        return self._robot_system
+
+    def __del__(self) -> None:
+        try:
+            self.disconnect()
+        except Exception:
+            pass
+
+    def _teleoperate_step(self, *, record: bool) -> So101ArmObs | None:
+        arm_obs = self._robot_system.teleope_step(if_record=record)
+        if arm_obs is None or not record:
+            return None
+        return self._to_arm_obs(arm_obs)
+
+    def _capture_camera_data(
+        self, *, async_mode: bool, timeout_ms: float
+    ) -> Dict[str, NDArray[np.float32] | NDArray[np.uint8] | None]:
+        camera_data: Dict[str, NDArray[np.float32] | NDArray[np.uint8] | None] = {}
+
+        for cam in self._cameras:
+            color_key = f"{cam.name}.rgb"
+            depth_key = f"{cam.name}.depth"
+
+            if not cam.is_connected:
+                camera_data[color_key] = None
+                if isinstance(cam, RealsenseCamera) and cam.config.is_depth_camera:
+                    camera_data[depth_key] = None
+                continue
+
+            try:
+                if async_mode and hasattr(cam, "async_read"):
+                    color_frame = cam.async_read(timeout_ms=timeout_ms)
+                else:
+                    color_frame = cam.read()
+                camera_data[color_key] = color_frame
+            except Exception as exc:
+                logger.warning("Camera %s failed to read color frame: %s", cam.name, exc)
+                camera_data[color_key] = None
+
+            if isinstance(cam, RealsenseCamera) and cam.config.is_depth_camera:
+                try:
+                    if async_mode and hasattr(cam, "async_read_depth"):
+                        depth_frame = cam.async_read_depth(timeout_ms=timeout_ms)
+                    else:
+                        depth_frame = cam.read_depth()
+                    camera_data[depth_key] = depth_frame
+                except Exception as exc:
+                    logger.warning("Camera %s failed to read depth frame: %s", cam.name, exc)
+                    camera_data[depth_key] = None
+
+        return camera_data
+
+    def _to_arm_obs(self, arm_data: object) -> So101ArmObs:
+        if isinstance(arm_data, So101ArmObs):
+            return arm_data
+        if isinstance(arm_data, dict):
+            leader = np.asarray(arm_data["leader"], dtype=np.float32)
+            follower = np.asarray(arm_data["follower"], dtype=np.float32)
+            return So101ArmObs(leader=leader, follower=follower)
+
+        leader = np.asarray(getattr(arm_data, "leader"), dtype=np.float32)
+        follower = np.asarray(getattr(arm_data, "follower"), dtype=np.float32)
+        return So101ArmObs(leader=leader, follower=follower)

--- a/src/robopy/robots/so101/so101_spacemouse.py
+++ b/src/robopy/robots/so101/so101_spacemouse.py
@@ -1,0 +1,379 @@
+"""SpaceMouse-based EE-space controller for SO-101."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from collections import defaultdict
+from typing import DefaultDict, Dict, List
+
+import numpy as np
+from numpy.typing import NDArray
+from rich.progress import Progress
+
+from robopy.config.input_config.spacemouse_config import SpaceMouseConfig
+from robopy.input.spacemouse import SpaceMouseReader
+from robopy.utils.worker.so101_save_worker import So101ArmObs, So101Obs
+
+from .so101_robot import So101Robot
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_deadzone(value: float, deadzone: float) -> float:
+    """Zero out values whose absolute magnitude is below *deadzone*."""
+    if abs(value) < deadzone:
+        return 0.0
+    return value
+
+
+class So101SpaceMouseController:
+    """Control an SO-101 follower arm via a 3Dconnexion SpaceMouse.
+
+    The SpaceMouse 6-DOF input (x, y, z, roll, pitch, yaw — all normalised
+    to ``[-1, 1]``) is mapped to incremental end-effector velocity commands.
+    At each control step the current EE pose is updated by the velocity
+    delta, then Inverse Kinematics converts the target pose to joint angles
+    that are sent to the follower arm.
+
+    The controller operates **without a physical leader arm** — the SpaceMouse
+    replaces it.  Gripper open/close is driven by the left/right buttons.
+
+    Args:
+        robot: A configured :class:`So101Robot` instance.  Only the follower
+            arm is used; a leader arm is *not* required.
+        spacemouse_config: Optional tuning parameters.  Defaults are
+            reasonable for desktop-scale manipulation.
+    """
+
+    def __init__(
+        self,
+        robot: So101Robot,
+        spacemouse_config: SpaceMouseConfig | None = None,
+    ) -> None:
+        self._robot = robot
+        self._sm_config = spacemouse_config or SpaceMouseConfig()
+        self._reader = SpaceMouseReader()
+
+    @property
+    def robot(self) -> So101Robot:
+        return self._robot
+
+    @property
+    def is_connected(self) -> bool:
+        return self._robot.is_connected and self._reader.is_running
+
+    def connect(self) -> None:
+        """Connect the robot and start the SpaceMouse reader."""
+        if not self._robot.is_connected:
+            self._robot.connect()
+        self._reader.start()
+        logger.info("So101SpaceMouseController connected.")
+
+    def disconnect(self) -> None:
+        """Stop the SpaceMouse reader and disconnect the robot."""
+        self._reader.stop()
+        self._robot.disconnect()
+        logger.info("So101SpaceMouseController disconnected.")
+
+    # ------------------------------------------------------------------
+    # Teleoperation
+    # ------------------------------------------------------------------
+
+    def teleoperation(self, max_seconds: float | None = None) -> None:
+        """Run real-time SpaceMouse → EE-space teleoperation.
+
+        The control loop reads the SpaceMouse at *control_hz*, computes the
+        incremental EE delta, runs IK and sends joint angles to the follower.
+
+        Args:
+            max_seconds: If given, stop after this many seconds.  Otherwise
+                the loop runs until interrupted (``KeyboardInterrupt``).
+        """
+        if not self.is_connected:
+            raise ConnectionError(
+                "Controller is not connected. Call connect() first."
+            )
+
+        cfg = self._sm_config
+        dt = 1.0 / cfg.control_hz
+
+        # Initialise current EE pose from the follower's actual position
+        current_joints_deg = self._read_follower_joints()
+        ee = So101Robot.forward_kinematics(current_joints_deg)
+        target_ee = np.array([ee.x, ee.y, ee.z, ee.pitch, ee.roll], dtype=np.float64)
+        gripper_deg = float(current_joints_deg[5]) if len(current_joints_deg) > 5 else 0.0
+        current_joints_for_ik = current_joints_deg.copy()
+
+        end_time = (time.perf_counter() + max_seconds) if max_seconds is not None else None
+
+        logger.info("SpaceMouse teleoperation started. Press Ctrl+C to stop.")
+        try:
+            while True:
+                loop_start = time.perf_counter()
+                if end_time is not None and loop_start >= end_time:
+                    break
+
+                target_ee, gripper_deg, current_joints_for_ik = self._control_step(
+                    target_ee, gripper_deg, current_joints_for_ik, dt
+                )
+
+                elapsed = time.perf_counter() - loop_start
+                time.sleep(max(0.0, dt - elapsed))
+
+        except KeyboardInterrupt:
+            logger.info("SpaceMouse teleoperation stopped by user.")
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def record_parallel(
+        self,
+        max_frame: int,
+        fps: int = 20,
+        control_hz: int | None = None,
+        is_async: bool = True,
+    ) -> So101Obs:
+        """Record a SpaceMouse-driven trajectory with camera observations.
+
+        Architecture mirrors :meth:`So101Robot.record_parallel` — a fast
+        control thread drives the arm while the main thread captures camera
+        frames at the requested *fps*.
+
+        The returned ``So101Obs.arms.leader`` contains the *commanded* joint
+        angles (IK output), so the trajectory can be replayed verbatim with
+        ``So101Robot.send()``.  ``So101Obs.arms.follower`` contains the
+        actual motor readings.
+
+        Args:
+            max_frame: Number of sensor frames to record.
+            fps: Camera / observation capture rate.
+            control_hz: SpaceMouse control loop rate (defaults to config).
+            is_async: Use asynchronous camera reads when available.
+
+        Returns:
+            ``So101Obs`` with arm and camera observations.
+        """
+        if max_frame <= 0:
+            raise ValueError("max_frame must be greater than 0.")
+        if fps <= 0:
+            raise ValueError("fps must be greater than 0.")
+
+        if not self.is_connected:
+            raise ConnectionError(
+                "Controller is not connected. Call connect() first."
+            )
+
+        hz = control_hz or self._sm_config.control_hz
+        dt = 1.0 / hz
+
+        max_processing_time_ms = 1000.0 / fps * 0.9
+
+        arm_obs_queue: queue.Queue[So101ArmObs] = queue.Queue(maxsize=hz * 2)
+        stop_event = threading.Event()
+
+        # Initialise EE state
+        current_joints_deg = self._read_follower_joints()
+        ee = So101Robot.forward_kinematics(current_joints_deg)
+        init_target_ee = np.array([ee.x, ee.y, ee.z, ee.pitch, ee.roll], dtype=np.float64)
+        init_gripper_deg = float(current_joints_deg[5]) if len(current_joints_deg) > 5 else 0.0
+        init_joints_for_ik = current_joints_deg.copy()
+
+        def control_worker() -> None:
+            target_ee = init_target_ee.copy()
+            gripper_deg = init_gripper_deg
+            joints_for_ik = init_joints_for_ik.copy()
+
+            while not stop_event.is_set():
+                loop_start = time.perf_counter()
+
+                target_ee, gripper_deg, joints_for_ik = self._control_step(
+                    target_ee, gripper_deg, joints_for_ik, dt
+                )
+
+                # Build observation: commanded joints as leader, actual as follower
+                commanded = joints_for_ik.copy()
+                try:
+                    actual = self._read_follower_joints()
+                except Exception:
+                    actual = commanded.copy()
+
+                arm_obs = So101ArmObs(
+                    leader=commanded.astype(np.float32),
+                    follower=actual.astype(np.float32),
+                )
+
+                try:
+                    arm_obs_queue.put(arm_obs, timeout=dt)
+                except queue.Full:
+                    pass
+
+                elapsed = time.perf_counter() - loop_start
+                time.sleep(max(0.0, dt - elapsed))
+
+        # Start control thread
+        control_thread = threading.Thread(target=control_worker, daemon=True)
+        control_thread.start()
+
+        # Main thread: capture sensor data at *fps*
+        leader_obs: List[NDArray[np.float32]] = []
+        follower_obs: List[NDArray[np.float32]] = []
+        camera_obs: DefaultDict[str, List[NDArray[np.float32] | NDArray[np.uint8] | None]] = (
+            defaultdict(list)
+        )
+
+        get_obs_interval = 1.0 / fps
+        max_processing_time = max_processing_time_ms / 1000.0
+        frame_count = 0
+        skipped_frames = 0
+        total_processing_time = 0.0
+
+        logger.info(
+            "SpaceMouse parallel recording: frames=%s, fps=%s, control_hz=%s",
+            max_frame, fps, hz,
+        )
+
+        try:
+            with Progress() as progress:
+                task = progress.add_task(
+                    "[green]Recording SO-101 (SpaceMouse)...", total=max_frame
+                )
+                while frame_count < max_frame:
+                    frame_start = time.perf_counter()
+
+                    # Get latest arm observation from control thread
+                    try:
+                        arm_obs = arm_obs_queue.get(timeout=get_obs_interval)
+                        while not arm_obs_queue.empty():
+                            arm_obs = arm_obs_queue.get_nowait()
+                    except queue.Empty:
+                        logger.warning("No arm observation available in time.")
+                        continue
+
+                    # Capture cameras
+                    sensor_data = self._robot.sensors_observation(
+                        timeout_ms=max_processing_time_ms / 2.0, async_mode=is_async
+                    )
+
+                    leader_obs.append(arm_obs.leader)
+                    follower_obs.append(arm_obs.follower)
+
+                    for cam_name, frame in sensor_data.items():
+                        camera_obs[cam_name].append(frame)
+
+                    frame_count += 1
+                    progress.update(task, advance=1)
+                    processing_time = time.perf_counter() - frame_start
+                    total_processing_time += processing_time
+
+                    if processing_time > max_processing_time:
+                        skipped_frames += 1
+                        logger.warning(
+                            "Frame %s took %.1f ms (> %.1f ms), skipping sleep",
+                            frame_count,
+                            processing_time * 1000.0,
+                            max_processing_time_ms,
+                        )
+                        continue
+
+                    sleep_time = max(0.0, get_obs_interval - processing_time)
+                    if sleep_time > 0:
+                        time.sleep(sleep_time)
+                progress.remove_task(task)
+
+        except KeyboardInterrupt:
+            logger.info("SpaceMouse recording interrupted by user.")
+            raise
+        except Exception as exc:
+            logger.error("Error during SpaceMouse parallel recording: %s", exc)
+            raise
+        finally:
+            stop_event.set()
+            control_thread.join(timeout=1.0)
+
+        if frame_count == 0:
+            raise RuntimeError("No frames captured during SpaceMouse recording.")
+
+        avg_proc = total_processing_time / frame_count * 1000.0
+        logger.info(
+            "SpaceMouse recording completed: frames=%s, skipped=%s, avg_proc=%.1f ms",
+            frame_count, skipped_frames, avg_proc,
+        )
+
+        leader_arr = np.asarray(leader_obs, dtype=np.float32)
+        follower_arr = np.asarray(follower_obs, dtype=np.float32)
+        arms = So101ArmObs(leader=leader_arr, follower=follower_arr)
+
+        camera_obs_np: Dict[str, NDArray[np.uint8] | NDArray[np.float32] | None] = {}
+        for cam_name, frames in camera_obs.items():
+            if frames and all(f is not None for f in frames):
+                camera_obs_np[cam_name] = np.asarray(frames)
+            else:
+                camera_obs_np[cam_name] = None
+
+        return So101Obs(arms=arms, cameras=camera_obs_np)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _control_step(
+        self,
+        target_ee: NDArray[np.float64],
+        gripper_deg: float,
+        current_joints_for_ik: NDArray[np.float32],
+        dt: float,
+    ) -> tuple[NDArray[np.float64], float, NDArray[np.float32]]:
+        """Execute one SpaceMouse → IK → send cycle.
+
+        Returns the updated ``(target_ee, gripper_deg, joint_angles_deg)``.
+        """
+        cfg = self._sm_config
+        sm = self._reader.get_state()
+
+        # Apply deadzone
+        sx = _apply_deadzone(sm.x, cfg.deadzone)
+        sy = _apply_deadzone(sm.y, cfg.deadzone)
+        sz = _apply_deadzone(sm.z, cfg.deadzone)
+        sp = _apply_deadzone(sm.pitch, cfg.deadzone)
+        sr = _apply_deadzone(sm.roll, cfg.deadzone)
+
+        # Compute EE delta
+        target_ee = target_ee.copy()
+        target_ee[0] += sx * cfg.linear_speed * dt
+        target_ee[1] += sy * cfg.linear_speed * dt
+        target_ee[2] += sz * cfg.linear_speed * dt
+        target_ee[3] += sp * cfg.angular_speed * dt
+        target_ee[4] += sr * cfg.angular_speed * dt
+
+        # Gripper: left button = close, right button = open
+        if sm.buttons[0]:
+            gripper_deg = max(0.0, gripper_deg - cfg.gripper_speed * dt)
+        if sm.buttons[1]:
+            gripper_deg = min(100.0, gripper_deg + cfg.gripper_speed * dt)
+
+        # IK → joint angles (degrees)
+        result = self._robot.inverse_kinematics(target_ee, current_joints_for_ik)
+
+        if not result.success:
+            logger.debug(
+                "IK best-effort: pos_err=%.4f m, ori_err=%.4f rad",
+                result.position_error,
+                result.orientation_error,
+            )
+
+        joint_deg = np.rad2deg(result.joint_angles_rad).astype(np.float32)
+        full_action = np.append(joint_deg, np.float32(gripper_deg))
+
+        # Send to follower
+        self._robot.send_frame_action(full_action)
+
+        return target_ee, gripper_deg, full_action
+
+    def _read_follower_joints(self) -> NDArray[np.float32]:
+        """Read current follower joint positions (degrees, 6-element)."""
+        obs = self._robot.get_arm_observation()
+        return obs.follower

--- a/src/robopy/robots/so101/so101_spacemouse.py
+++ b/src/robopy/robots/so101/so101_spacemouse.py
@@ -115,9 +115,7 @@ class So101SpaceMouseController:
                 the loop runs until interrupted (``KeyboardInterrupt``).
         """
         if not self.is_connected:
-            raise ConnectionError(
-                "Controller is not connected. Call connect() first."
-            )
+            raise ConnectionError("Controller is not connected. Call connect() first.")
 
         cfg = self._sm_config
         dt = 1.0 / cfg.control_hz
@@ -186,9 +184,7 @@ class So101SpaceMouseController:
             raise ValueError("fps must be greater than 0.")
 
         if not self.is_connected:
-            raise ConnectionError(
-                "Controller is not connected. Call connect() first."
-            )
+            raise ConnectionError("Controller is not connected. Call connect() first.")
 
         hz = control_hz or self._sm_config.control_hz
         dt = 1.0 / hz
@@ -257,14 +253,14 @@ class So101SpaceMouseController:
 
         logger.info(
             "SpaceMouse parallel recording: frames=%s, fps=%s, control_hz=%s",
-            max_frame, fps, hz,
+            max_frame,
+            fps,
+            hz,
         )
 
         try:
             with Progress() as progress:
-                task = progress.add_task(
-                    "[green]Recording SO-101 (SpaceMouse)...", total=max_frame
-                )
+                task = progress.add_task("[green]Recording SO-101 (SpaceMouse)...", total=max_frame)
                 while frame_count < max_frame:
                     frame_start = time.perf_counter()
 
@@ -324,7 +320,9 @@ class So101SpaceMouseController:
         avg_proc = total_processing_time / frame_count * 1000.0
         logger.info(
             "SpaceMouse recording completed: frames=%s, skipped=%s, avg_proc=%.1f ms",
-            frame_count, skipped_frames, avg_proc,
+            frame_count,
+            skipped_frames,
+            avg_proc,
         )
 
         leader_arr = np.asarray(leader_obs, dtype=np.float32)
@@ -377,9 +375,7 @@ class So101SpaceMouseController:
             self._filter_initialized = True
         elif cfg.input_smoothing > 0.0:
             alpha = 1.0 - cfg.input_smoothing
-            self._filtered_axes = (
-                alpha * raw_axes + cfg.input_smoothing * self._filtered_axes
-            )
+            self._filtered_axes = alpha * raw_axes + cfg.input_smoothing * self._filtered_axes
         else:
             self._filtered_axes = raw_axes.copy()
         sx, sy, sz, sp, sr = self._filtered_axes
@@ -404,7 +400,7 @@ class So101SpaceMouseController:
 
         # IK → joint angles (degrees)
         result = self._robot.inverse_kinematics(
-            target_ee, current_joints_for_ik, ik_config=self._ik_config
+            target_ee.astype(np.float32), current_joints_for_ik, ik_config=self._ik_config
         )
 
         if not result.success:

--- a/src/robopy/utils/exp_interface/__init__.py
+++ b/src/robopy/utils/exp_interface/__init__.py
@@ -8,8 +8,9 @@ if TYPE_CHECKING:
     from .exp_handler import ExpHandler
     from .koch_exp_handler import KochExpHandler
     from .rakuda_exp_handler import RakudaExpHandler
+    from .so101_spacemouse_exp_handler import So101SpaceMouseExpHandler
 
-__all__ = ["KochExpHandler", "RakudaExpHandler"]
+__all__ = ["KochExpHandler", "RakudaExpHandler", "So101SpaceMouseExpHandler"]
 
 
 def __getattr__(name: str) -> type[ExpHandler[Any, Any, Any, Any]]:
@@ -22,4 +23,8 @@ def __getattr__(name: str) -> type[ExpHandler[Any, Any, Any, Any]]:
         from .rakuda_exp_handler import RakudaExpHandler
 
         return RakudaExpHandler
+    if name == "So101SpaceMouseExpHandler":
+        from .so101_spacemouse_exp_handler import So101SpaceMouseExpHandler
+
+        return So101SpaceMouseExpHandler
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/robopy/utils/exp_interface/so101_spacemouse_exp_handler.py
+++ b/src/robopy/utils/exp_interface/so101_spacemouse_exp_handler.py
@@ -1,0 +1,205 @@
+"""Experiment handler for SO-101 with SpaceMouse teleoperation."""
+
+from __future__ import annotations
+
+from time import sleep
+from typing import Any, Dict
+
+import numpy as np
+from numpy.typing import NDArray
+
+from robopy.config.input_config.spacemouse_config import SpaceMouseConfig
+from robopy.config.robot_config.so101_config import So101Config
+from robopy.robots.so101.so101_robot import So101Robot
+from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+from robopy.utils.worker.so101_save_worker import So101Obs, So101SaveWorker
+
+from .exp_handler import ExpHandler
+from .meta_data_config import MetaDataConfig
+
+
+class So101SpaceMouseExpHandler(
+    ExpHandler[So101Obs, So101Robot, So101Config, So101SaveWorker]
+):
+    """Experiment handler using SpaceMouse for SO-101 data collection.
+
+    This handler replaces the leader arm with a SpaceMouse device for
+    teleoperation and data recording.  It follows the standard
+    :class:`ExpHandler` interface so that the interactive ``record_save()``
+    workflow (warmup → record → save) works identically.
+    """
+
+    def __init__(
+        self,
+        so101_config: So101Config,
+        metadata_config: MetaDataConfig,
+        spacemouse_config: SpaceMouseConfig | None = None,
+        fps: int = 20,
+    ) -> None:
+        if fps < 1 or fps > 60:
+            raise ValueError("FPS must be between 1 and 60")
+
+        super().__init__(metadata_config, fps)
+        self._config = so101_config
+        self._robot = So101Robot(cfg=self._config)
+        self._controller = So101SpaceMouseController(
+            self._robot, spacemouse_config
+        )
+        self._save_worker = So101SaveWorker(fps=self.fps)
+
+        try:
+            self._controller.connect()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to connect SpaceMouse controller: {exc}"
+            ) from exc
+
+    @property
+    def robot(self) -> So101Robot:
+        return self._robot
+
+    @property
+    def save_worker(self) -> So101SaveWorker:
+        return self._save_worker
+
+    @property
+    def config(self) -> So101Config:
+        return self._config
+
+    @property
+    def controller(self) -> So101SpaceMouseController:
+        return self._controller
+
+    def record(self, max_frames: int, if_async: bool = True) -> So101Obs:
+        if max_frames <= 0:
+            raise ValueError("max_frames must be greater than 0")
+
+        try:
+            obs = self._controller.record_parallel(
+                max_frame=max_frames,
+                fps=self.fps,
+                is_async=if_async,
+            )
+        except KeyboardInterrupt as exc:
+            sleep(0.5)
+            self.close()
+            raise RuntimeError("Recording stopped by user") from exc
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to record with SpaceMouse: {exc}"
+            ) from exc
+
+        return obs
+
+    def send(
+        self,
+        max_frame: int,
+        fps: int,
+        leader_action: NDArray[np.float32],
+    ) -> None:
+        self._robot.send(
+            max_frame=max_frame, fps=fps, leader_action=leader_action
+        )
+
+    def _extract_data_shapes(self, obs: So101Obs) -> dict[str, Any]:
+        data_shape: Dict[str, Dict[str, Any]] = {}
+        data_shape["arms"] = {
+            "leader": list(obs.arms.leader.shape),
+            "follower": list(obs.arms.follower.shape),
+        }
+
+        if obs.cameras:
+            data_shape["sensors"] = {"cameras": {}}
+            for name, frames in obs.cameras.items():
+                if frames is None:
+                    data_shape["sensors"]["cameras"][name] = None
+                else:
+                    data_shape["sensors"]["cameras"][name] = list(frames.shape)
+
+        return data_shape
+
+    def close(self) -> None:
+        """Disconnect SpaceMouse + robot and shut down the save worker."""
+        try:
+            self._controller.disconnect()
+        except Exception:
+            pass
+        if self._save_worker:
+            try:
+                self._save_worker.shutdown()
+            except Exception:
+                pass
+
+    def record_save(
+        self,
+        max_frames: int,
+        save_path: str,
+        if_async: bool = True,
+        save_gif: bool = True,
+        warmup_time: int = 5,
+    ) -> None:
+        """Interactive record-and-save loop using SpaceMouse.
+
+        Overrides the base class to use SpaceMouse teleoperation for the
+        warmup phase (instead of the leader-arm-based teleoperation).
+        """
+        import os
+
+        try:
+            print("Starting SpaceMouse recording session...")
+            if not self._controller.is_connected:
+                self._controller.connect()
+
+            while True:
+                print("Press 'Enter' to warm up, or 'q' to quit")
+                input_str = input()
+                if input_str.lower() == "q":
+                    print("Exiting...")
+                    self.close()
+                    sleep(0.5)
+                    return
+
+                print(f"Warming up for {warmup_time} seconds (SpaceMouse active)...")
+                self._controller.teleoperation(max_seconds=warmup_time)
+
+                print("Press 'Enter' to start recording...")
+                input_str = input()
+                print("Recording with SpaceMouse...")
+
+                if if_async:
+                    print("Using asynchronous recording...")
+
+                obs = self.record(max_frames=max_frames, if_async=if_async)
+
+                print(
+                    "Recording finished. Print 1~9 to save data,"
+                    " or 'e' to record again"
+                )
+                input_str = input()
+
+                if input_str.lower() == "e":
+                    print("Recording again...")
+                    continue
+                elif input_str in [str(i) for i in range(1, 10)]:
+                    save_dir = os.path.join("data", f"{save_path}", f"{input_str}")
+                    count = 1
+                    unique_save_dir = save_dir + f"_{count}"
+                    while os.path.exists(unique_save_dir):
+                        unique_save_dir = f"{save_dir}_{count}"
+                        count += 1
+                    os.makedirs(unique_save_dir)
+
+                    self.save_worker.save_all_obs(obs, unique_save_dir, save_gif)
+                    data_shape = self._extract_data_shapes(obs)
+                    self.save_metadata(unique_save_dir, data_shape)
+                else:
+                    print("Invalid input. Exiting...")
+                    self.close()
+                    return
+        except Exception as e:
+            self.close()
+            raise RuntimeError(f"Failed to record from SpaceMouse: {e}")
+        except KeyboardInterrupt:
+            print("Recording stopped by user...")
+            sleep(0.5)
+            self.close()

--- a/src/robopy/utils/exp_interface/so101_spacemouse_exp_handler.py
+++ b/src/robopy/utils/exp_interface/so101_spacemouse_exp_handler.py
@@ -18,9 +18,7 @@ from .exp_handler import ExpHandler
 from .meta_data_config import MetaDataConfig
 
 
-class So101SpaceMouseExpHandler(
-    ExpHandler[So101Obs, So101Robot, So101Config, So101SaveWorker]
-):
+class So101SpaceMouseExpHandler(ExpHandler[So101Obs, So101Robot, So101Config, So101SaveWorker]):
     """Experiment handler using SpaceMouse for SO-101 data collection.
 
     This handler replaces the leader arm with a SpaceMouse device for
@@ -42,17 +40,13 @@ class So101SpaceMouseExpHandler(
         super().__init__(metadata_config, fps)
         self._config = so101_config
         self._robot = So101Robot(cfg=self._config)
-        self._controller = So101SpaceMouseController(
-            self._robot, spacemouse_config
-        )
+        self._controller = So101SpaceMouseController(self._robot, spacemouse_config)
         self._save_worker = So101SaveWorker(fps=self.fps)
 
         try:
             self._controller.connect()
         except Exception as exc:
-            raise RuntimeError(
-                f"Failed to connect SpaceMouse controller: {exc}"
-            ) from exc
+            raise RuntimeError(f"Failed to connect SpaceMouse controller: {exc}") from exc
 
     @property
     def robot(self) -> So101Robot:
@@ -85,9 +79,7 @@ class So101SpaceMouseExpHandler(
             self.close()
             raise RuntimeError("Recording stopped by user") from exc
         except Exception as exc:
-            raise RuntimeError(
-                f"Failed to record with SpaceMouse: {exc}"
-            ) from exc
+            raise RuntimeError(f"Failed to record with SpaceMouse: {exc}") from exc
 
         return obs
 
@@ -97,9 +89,7 @@ class So101SpaceMouseExpHandler(
         fps: int,
         leader_action: NDArray[np.float32],
     ) -> None:
-        self._robot.send(
-            max_frame=max_frame, fps=fps, leader_action=leader_action
-        )
+        self._robot.send(max_frame=max_frame, fps=fps, leader_action=leader_action)
 
     def _extract_data_shapes(self, obs: So101Obs) -> dict[str, Any]:
         data_shape: Dict[str, Dict[str, Any]] = {}
@@ -171,10 +161,7 @@ class So101SpaceMouseExpHandler(
 
                 obs = self.record(max_frames=max_frames, if_async=if_async)
 
-                print(
-                    "Recording finished. Print 1~9 to save data,"
-                    " or 'e' to record again"
-                )
+                print("Recording finished. Print 1~9 to save data, or 'e' to record again")
                 input_str = input()
 
                 if input_str.lower() == "e":

--- a/src/robopy/utils/worker/so101_save_worker.py
+++ b/src/robopy/utils/worker/so101_save_worker.py
@@ -1,0 +1,169 @@
+import os
+from concurrent.futures import Future
+from dataclasses import dataclass
+from logging import getLogger
+from typing import Dict, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..h5_handler import H5Handler
+from .save_worker import HierarchicalTaskData, SaveTask, SaveWorker
+
+logger = getLogger(__name__)
+
+
+@dataclass
+class So101ArmObs:
+    leader: NDArray[np.float32]
+    follower: NDArray[np.float32]
+
+
+@dataclass
+class So101Obs:
+    arms: So101ArmObs
+    cameras: Dict[str, NDArray[np.uint8] | NDArray[np.float32] | None]
+
+
+class So101SaveWorker(SaveWorker[So101Obs]):
+    """SO-101 robot save worker for async data persistence."""
+
+    def __init__(self, fps: int, worker_num: int = 2) -> None:
+        super().__init__(worker_num=worker_num)
+        self.fps = fps
+
+    def _process_task(self, task: SaveTask) -> Future[None] | None:
+        match task.task_type:
+            case "hierarchical":
+                data = cast(HierarchicalTaskData, task.data)
+                return self._executor.submit(
+                    self._save_hierarchical_h5,
+                    data,
+                    task.save_path,
+                )
+            case "arm":
+                leader, follower = cast(tuple[NDArray[np.float32], NDArray[np.float32]], task.data)
+                return self._executor.submit(
+                    self.save_arm_datas,
+                    leader,
+                    follower,
+                    task.save_path,
+                )
+            case "gif":
+                frames = cast(NDArray[np.float32], task.data)
+                return self._executor.submit(self._save_camera_gif, frames, task.save_path)
+            case _:
+                logger.warning("Unknown task type: %s", task.task_type)
+                return None
+
+    def save_arm_datas(
+        self, leader_obs: NDArray[np.float32], follower_obs: NDArray[np.float32], path: str
+    ) -> None:
+        """Save arm data in HDF5 format."""
+        os.makedirs(path, exist_ok=True)
+        hierarchical_data = {
+            "arm": {
+                "leader": leader_obs,
+                "follower": follower_obs,
+            }
+        }
+        arm_h5_path = os.path.join(path, "so101_arm_observations.h5")
+        H5Handler.save_hierarchical(hierarchical_data, arm_h5_path, compress=True)
+        logger.info("Saved SO-101 arm observations to HDF5: %s", arm_h5_path)
+
+    def save_all_obs(self, obs: So101Obs, save_path: str, save_gif: bool) -> None:
+        """Save observation data asynchronously."""
+        os.makedirs(save_path, exist_ok=True)
+        camera_data, leader, follower = self._prepare_obs(obs, save_path)
+
+        hierarchical_data = self._build_hierarchical_data(camera_data, leader, follower)
+        h5_path = os.path.join(save_path, "so101_observations.h5")
+        self.enqueue_save_task(
+            SaveTask(
+                task_type="hierarchical",
+                data=hierarchical_data,
+                save_path=h5_path,
+            )
+        )
+
+        self.enqueue_save_task(
+            SaveTask(
+                task_type="arm",
+                data=(leader, follower),
+                save_path=os.path.join(save_path, "arm"),
+            )
+        )
+
+        if save_gif:
+            gif_root = os.path.join(save_path, "camera_gif")
+            for name, frames in camera_data.items():
+                gif_path = os.path.join(gif_root, name, f"{name}.gif")
+                self.enqueue_save_task(
+                    SaveTask(
+                        task_type="gif",
+                        data=frames,
+                        save_path=gif_path,
+                    )
+                )
+
+        logger.info("Enqueued SO-101 observation save tasks: %s", save_path)
+
+    def shutdown(self) -> None:
+        super().shutdown()
+
+    def _prepare_obs(
+        self, obs: So101Obs, save_dir: str
+    ) -> tuple[
+        Dict[str, NDArray[np.float32] | NDArray[np.uint8]], NDArray[np.float32], NDArray[np.float32]
+    ]:
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+
+        camera_data = {name: frames for name, frames in obs.cameras.items() if frames is not None}
+        if not camera_data:
+            logger.warning("No camera data available.")
+
+        leader = obs.arms.leader
+        follower = obs.arms.follower
+        return camera_data, leader, follower
+
+    def _save_camera_gif(self, frames: NDArray[np.float32] | NDArray[np.uint8], path: str) -> None:
+        """Save camera frames as GIF."""
+        try:
+            import imageio.v2 as imageio
+        except ImportError:
+            logger.warning("imageio is not installed, skipping GIF save.")
+            return
+
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        frame_data = frames
+        if frame_data.shape[-3] == 3 or frame_data.shape[-3] == 1:
+            frame_data = frame_data.transpose(0, 2, 3, 1)
+        if frame_data.shape[-1] == 1:
+            frame_data = frame_data[..., 0]
+            frame_data = frame_data.astype(np.float32) / max(float(np.max(frame_data)), 1e-6) * 255
+        if frame_data.dtype != np.uint8:
+            frame_data = np.clip(frame_data, 0, 255).astype(np.uint8)
+        imageio.mimsave(path, list(frame_data), fps=self.fps)
+        logger.info("Saved GIF to %s.", path)
+
+    def _save_hierarchical_h5(self, data_dict: HierarchicalTaskData, file_path: str) -> None:
+        H5Handler.save_hierarchical(data_dict, file_path, compress=True)
+        logger.info("Saved SO-101 observations to HDF5: %s", file_path)
+
+    def _build_hierarchical_data(
+        self,
+        camera_data: Dict[str, NDArray[np.float32] | NDArray[np.uint8]],
+        leader: NDArray[np.float32],
+        follower: NDArray[np.float32],
+    ) -> HierarchicalTaskData:
+        hierarchical_data: HierarchicalTaskData = {
+            "arm": {
+                "leader": leader,
+                "follower": follower,
+            },
+            "camera": {},
+        }
+        for name, frames in camera_data.items():
+            hierarchical_data["camera"][name] = frames
+        return hierarchical_data

--- a/tests/test_kinematics/test_chain.py
+++ b/tests/test_kinematics/test_chain.py
@@ -11,7 +11,8 @@ def _simple_2dof_chain() -> KinematicChain:
     """A simple 2-joint planar chain for testing.
 
     Joint layout (all rotations about Z):
-      base → translate(0.1, 0, 0) → rot_z(q0) → translate(0.2, 0, 0) → rot_z(q1) → EE at (0.15, 0, 0)
+      base → translate(0.1, 0, 0) → rot_z(q0) → translate(0.2, 0, 0) → rot_z(q1) →
+      EE at (0.15, 0, 0)
     """
     joints = [
         RevoluteJoint(

--- a/tests/test_kinematics/test_chain.py
+++ b/tests/test_kinematics/test_chain.py
@@ -1,0 +1,102 @@
+"""Tests for robopy.kinematics.chain."""
+
+import numpy as np
+import pytest
+
+from robopy.kinematics.chain import KinematicChain, RevoluteJoint
+from robopy.kinematics.transforms import translation
+
+
+def _simple_2dof_chain() -> KinematicChain:
+    """A simple 2-joint planar chain for testing.
+
+    Joint layout (all rotations about Z):
+      base → translate(0.1, 0, 0) → rot_z(q0) → translate(0.2, 0, 0) → rot_z(q1) → EE at (0.15, 0, 0)
+    """
+    joints = [
+        RevoluteJoint(
+            name="j0",
+            parent_to_joint=translation(0.1, 0.0, 0.0),
+            axis="z",
+            lower_limit_rad=-np.pi,
+            upper_limit_rad=np.pi,
+        ),
+        RevoluteJoint(
+            name="j1",
+            parent_to_joint=translation(0.2, 0.0, 0.0),
+            axis="z",
+            lower_limit_rad=-np.pi,
+            upper_limit_rad=np.pi,
+        ),
+    ]
+    ee = translation(0.15, 0.0, 0.0)
+    return KinematicChain(joints=joints, ee_fixed_transform=ee)
+
+
+class TestKinematicChain:
+    def test_properties(self):
+        chain = _simple_2dof_chain()
+        assert chain.n_joints == 2
+        assert chain.joint_names == ["j0", "j1"]
+
+    def test_fk_zeros(self):
+        """All joints at zero → EE at sum of offsets along X."""
+        chain = _simple_2dof_chain()
+        T = chain.forward_kinematics_matrix(np.array([0.0, 0.0]))
+        # x = 0.1 + 0.2 + 0.15 = 0.45, y = 0, z = 0
+        np.testing.assert_allclose(T[:3, 3], [0.45, 0.0, 0.0], atol=1e-14)
+
+    def test_fk_pose_zeros(self):
+        chain = _simple_2dof_chain()
+        pose = chain.forward_kinematics(np.array([0.0, 0.0]))
+        assert pose.shape == (5,)
+        np.testing.assert_allclose(pose[:3], [0.45, 0.0, 0.0], atol=1e-14)
+
+    def test_fk_90_first_joint(self):
+        """Rotate first joint 90° about Z → second link points in +Y."""
+        chain = _simple_2dof_chain()
+        T = chain.forward_kinematics_matrix(np.array([np.pi / 2, 0.0]))
+        # After q0=90deg: the 0.2 and 0.15 offsets now go in Y direction
+        # x = 0.1, y = 0.2 + 0.15 = 0.35
+        np.testing.assert_allclose(T[0, 3], 0.1, atol=1e-14)
+        np.testing.assert_allclose(T[1, 3], 0.35, atol=1e-14)
+        np.testing.assert_allclose(T[2, 3], 0.0, atol=1e-14)
+
+    def test_wrong_number_of_angles(self):
+        chain = _simple_2dof_chain()
+        with pytest.raises(ValueError, match="Expected 2"):
+            chain.forward_kinematics(np.array([0.0]))
+
+    def test_jacobian_shape(self):
+        chain = _simple_2dof_chain()
+        J = chain.jacobian(np.array([0.0, 0.0]))
+        assert J.shape == (5, 2)
+
+    def test_jacobian_finite_difference_consistency(self):
+        """Jacobian should be consistent with finite-difference check."""
+        chain = _simple_2dof_chain()
+        q = np.array([0.3, -0.5])
+        J = chain.jacobian(q, delta=1e-6)
+
+        # Verify with a larger delta for comparison
+        J2 = chain.jacobian(q, delta=1e-4)
+        # Should agree to within O(delta^2)
+        np.testing.assert_allclose(J, J2, atol=1e-5)
+
+    def test_clamp_to_limits(self):
+        chain = _simple_2dof_chain()
+        q = np.array([5.0, -5.0])
+        clamped = chain.clamp_to_limits(q)
+        np.testing.assert_allclose(clamped, [np.pi, -np.pi], atol=1e-14)
+
+
+class TestRevoluteJoint:
+    def test_invalid_axis(self):
+        with pytest.raises(ValueError, match="axis must be"):
+            RevoluteJoint(
+                name="bad",
+                parent_to_joint=np.eye(4),
+                axis="w",
+                lower_limit_rad=0,
+                upper_limit_rad=1,
+            )

--- a/tests/test_kinematics/test_ik_solver.py
+++ b/tests/test_kinematics/test_ik_solver.py
@@ -1,7 +1,6 @@
 """Tests for robopy.kinematics.ik_solver."""
 
 import numpy as np
-import pytest
 
 from robopy.kinematics.chain import KinematicChain, RevoluteJoint
 from robopy.kinematics.ik_solver import IKConfig, IKResult, IKSolver
@@ -70,7 +69,9 @@ class TestIKSolverSimple:
             recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
 
             np.testing.assert_allclose(
-                recovered_pose[:3], target_pose[:3], atol=1e-3,
+                recovered_pose[:3],
+                target_pose[:3],
+                atol=1e-3,
                 err_msg="Position mismatch in FK→IK→FK roundtrip",
             )
 
@@ -114,7 +115,9 @@ class TestIKSolverSO101:
             recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
 
             np.testing.assert_allclose(
-                recovered_pose[:3], target_pose[:3], atol=5e-3,
+                recovered_pose[:3],
+                target_pose[:3],
+                atol=5e-3,
                 err_msg="SO-101 FK→IK→FK position mismatch",
             )
 
@@ -161,6 +164,8 @@ class TestIKSolverKoch:
             recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
 
             np.testing.assert_allclose(
-                recovered_pose[:3], target_pose[:3], atol=5e-3,
+                recovered_pose[:3],
+                target_pose[:3],
+                atol=5e-3,
                 err_msg="Koch FK→IK→FK position mismatch",
             )

--- a/tests/test_kinematics/test_ik_solver.py
+++ b/tests/test_kinematics/test_ik_solver.py
@@ -1,0 +1,166 @@
+"""Tests for robopy.kinematics.ik_solver."""
+
+import numpy as np
+import pytest
+
+from robopy.kinematics.chain import KinematicChain, RevoluteJoint
+from robopy.kinematics.ik_solver import IKConfig, IKResult, IKSolver
+from robopy.kinematics.robot_chains import koch_chain, so101_chain
+from robopy.kinematics.transforms import translation
+
+
+def _simple_3dof_chain() -> KinematicChain:
+    """3-DOF chain with X/Y/Z rotation — enough to reach 3D positions."""
+    joints = [
+        RevoluteJoint(
+            name="j0",
+            parent_to_joint=translation(0.0, 0.0, 0.05),
+            axis="y",
+            lower_limit_rad=-np.pi,
+            upper_limit_rad=np.pi,
+        ),
+        RevoluteJoint(
+            name="j1",
+            parent_to_joint=translation(0.0, 0.0, 0.0),
+            axis="x",
+            lower_limit_rad=-np.pi / 2,
+            upper_limit_rad=np.pi / 2,
+        ),
+        RevoluteJoint(
+            name="j2",
+            parent_to_joint=translation(-0.15, 0.0, 0.0),
+            axis="x",
+            lower_limit_rad=-np.pi / 2,
+            upper_limit_rad=np.pi / 2,
+        ),
+    ]
+    ee = translation(-0.1, 0.0, 0.0)
+    return KinematicChain(joints=joints, ee_fixed_transform=ee)
+
+
+class TestIKSolverSimple:
+    """IK solver tests with a simple 3-DOF chain."""
+
+    def test_solve_at_home(self):
+        """IK at the home (zero-angle) pose should converge trivially."""
+        chain = _simple_3dof_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(3))
+        result = solver.solve(home_pose, np.zeros(3))
+        assert result.success
+        assert result.position_error < 1e-4
+
+    def test_roundtrip(self):
+        """FK → IK → FK should recover the original pose."""
+        chain = _simple_3dof_chain()
+        solver = IKSolver(chain, IKConfig(max_iterations=200))
+
+        rng = np.random.default_rng(42)
+        for _ in range(5):
+            q_rand = rng.uniform(
+                chain.lower_limits_rad * 0.5,
+                chain.upper_limits_rad * 0.5,
+            )
+            target_pose = chain.forward_kinematics(q_rand)
+            # Use a slightly perturbed starting point
+            q_init = q_rand + rng.normal(0, 0.1, size=3)
+            q_init = chain.clamp_to_limits(q_init)
+
+            result = solver.solve(target_pose, q_init)
+            recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
+
+            np.testing.assert_allclose(
+                recovered_pose[:3], target_pose[:3], atol=1e-3,
+                err_msg="Position mismatch in FK→IK→FK roundtrip",
+            )
+
+    def test_result_fields(self):
+        chain = _simple_3dof_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(3))
+        result = solver.solve(home_pose, np.zeros(3))
+        assert isinstance(result, IKResult)
+        assert isinstance(result.success, bool)
+        assert isinstance(result.iterations, int)
+        assert result.iterations >= 1
+
+
+class TestIKSolverSO101:
+    """IK tests using the real SO-101 chain definition."""
+
+    def test_home_pose_roundtrip(self):
+        chain = so101_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(5))
+        result = solver.solve(home_pose, np.zeros(5))
+        assert result.success
+        assert result.position_error < 1e-3
+
+    def test_random_roundtrip(self):
+        chain = so101_chain()
+        solver = IKSolver(chain, IKConfig(max_iterations=200))
+        rng = np.random.default_rng(123)
+
+        for _ in range(5):
+            q_rand = rng.uniform(
+                chain.lower_limits_rad * 0.3,
+                chain.upper_limits_rad * 0.3,
+            )
+            target_pose = chain.forward_kinematics(q_rand)
+            q_init = q_rand + rng.normal(0, 0.05, size=5)
+            q_init = chain.clamp_to_limits(q_init)
+
+            result = solver.solve(target_pose, q_init)
+            recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
+
+            np.testing.assert_allclose(
+                recovered_pose[:3], target_pose[:3], atol=5e-3,
+                err_msg="SO-101 FK→IK→FK position mismatch",
+            )
+
+    def test_joint_limits_respected(self):
+        chain = so101_chain()
+        config = IKConfig(joint_limit_margin_rad=0.02)
+        solver = IKSolver(chain, config)
+
+        home_pose = chain.forward_kinematics(np.zeros(5))
+        result = solver.solve(home_pose, np.zeros(5))
+
+        lower = chain.lower_limits_rad + config.joint_limit_margin_rad
+        upper = chain.upper_limits_rad - config.joint_limit_margin_rad
+        assert np.all(result.joint_angles_rad >= lower - 1e-10)
+        assert np.all(result.joint_angles_rad <= upper + 1e-10)
+
+
+class TestIKSolverKoch:
+    """IK tests using the Koch chain definition (estimated parameters)."""
+
+    def test_home_pose_roundtrip(self):
+        chain = koch_chain()
+        solver = IKSolver(chain)
+        home_pose = chain.forward_kinematics(np.zeros(5))
+        result = solver.solve(home_pose, np.zeros(5))
+        assert result.success
+        assert result.position_error < 1e-3
+
+    def test_random_roundtrip(self):
+        chain = koch_chain()
+        solver = IKSolver(chain, IKConfig(max_iterations=200))
+        rng = np.random.default_rng(456)
+
+        for _ in range(5):
+            q_rand = rng.uniform(
+                chain.lower_limits_rad * 0.3,
+                chain.upper_limits_rad * 0.3,
+            )
+            target_pose = chain.forward_kinematics(q_rand)
+            q_init = q_rand + rng.normal(0, 0.05, size=5)
+            q_init = chain.clamp_to_limits(q_init)
+
+            result = solver.solve(target_pose, q_init)
+            recovered_pose = chain.forward_kinematics(result.joint_angles_rad)
+
+            np.testing.assert_allclose(
+                recovered_pose[:3], target_pose[:3], atol=5e-3,
+                err_msg="Koch FK→IK→FK position mismatch",
+            )

--- a/tests/test_kinematics/test_robot_chains.py
+++ b/tests/test_kinematics/test_robot_chains.py
@@ -1,0 +1,71 @@
+"""Smoke tests for robot-specific kinematic chain factories."""
+
+import numpy as np
+
+from robopy.kinematics.ee_pose import EEPose
+from robopy.kinematics.robot_chains import koch_chain, so101_chain
+
+
+class TestSO101Chain:
+    def test_creation(self):
+        chain = so101_chain()
+        assert chain.n_joints == 5
+        assert chain.joint_names == [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+        ]
+
+    def test_fk_home_position(self):
+        """At zero angles the EE should be at the sum of all offsets."""
+        chain = so101_chain()
+        T = chain.forward_kinematics_matrix(np.zeros(5))
+        # The EE should be at a reasonable position (non-zero, within arm reach)
+        pos = T[:3, 3]
+        reach = np.linalg.norm(pos)
+        assert 0.01 < reach < 0.6, f"Unexpected reach {reach} m at home"
+
+    def test_fk_returns_ee_pose(self):
+        chain = so101_chain()
+        pose = chain.forward_kinematics(np.zeros(5))
+        assert pose.shape == (5,)
+        ee = EEPose.from_array(pose)
+        assert isinstance(ee, EEPose)
+
+    def test_joint_limits(self):
+        chain = so101_chain()
+        lower = chain.lower_limits_rad
+        upper = chain.upper_limits_rad
+        assert len(lower) == 5
+        assert len(upper) == 5
+        assert np.all(lower < upper)
+
+
+class TestKochChain:
+    def test_creation(self):
+        chain = koch_chain()
+        assert chain.n_joints == 5
+        assert chain.joint_names == [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow",
+            "wrist_flex",
+            "wrist_roll",
+        ]
+
+    def test_fk_home_position(self):
+        chain = koch_chain()
+        T = chain.forward_kinematics_matrix(np.zeros(5))
+        pos = T[:3, 3]
+        reach = np.linalg.norm(pos)
+        assert 0.01 < reach < 0.5, f"Unexpected reach {reach} m at home"
+
+    def test_joint_limits(self):
+        chain = koch_chain()
+        lower = chain.lower_limits_rad
+        upper = chain.upper_limits_rad
+        assert len(lower) == 5
+        assert len(upper) == 5
+        assert np.all(lower < upper)

--- a/tests/test_kinematics/test_robot_chains.py
+++ b/tests/test_kinematics/test_robot_chains.py
@@ -27,6 +27,46 @@ class TestSO101Chain:
         reach = np.linalg.norm(pos)
         assert 0.01 < reach < 0.6, f"Unexpected reach {reach} m at home"
 
+    def test_fk_home_position_values(self):
+        """Home position must match the URDF FK (arm extended forward/up)."""
+        chain = so101_chain()
+        T = chain.forward_kinematics_matrix(np.zeros(5))
+        pos = T[:3, 3]
+        # Expected from URDF: arm extended forward in +X, raised in +Z.
+        np.testing.assert_allclose(pos[0], 0.391, atol=0.005)  # ~0.39 m forward
+        assert pos[0] > 0.3, "Home x must be positive (arm forward)"
+        np.testing.assert_allclose(pos[1], 0.0, atol=0.005)    # centred in Y
+        np.testing.assert_allclose(pos[2], 0.227, atol=0.005)  # ~0.23 m high
+
+    def test_fk_home_all_axes_z(self):
+        """All joints in the SO-101 URDF rotate about local Z."""
+        chain = so101_chain()
+        for j in chain._joints:
+            assert j.axis == "z", f"Joint {j.name} axis should be 'z', got '{j.axis}'"
+
+    def test_shoulder_pan_swings_y(self):
+        """Shoulder pan should swing the EE left/right (±Y)."""
+        chain = so101_chain()
+        home = chain.forward_kinematics(np.zeros(5))
+        q_pos = np.array([0.3, 0, 0, 0, 0])
+        q_neg = np.array([-0.3, 0, 0, 0, 0])
+        pose_pos = chain.forward_kinematics(q_pos)
+        pose_neg = chain.forward_kinematics(q_neg)
+        # +pan → -Y, -pan → +Y (URDF convention)
+        assert pose_pos[1] < home[1], "Positive pan should move EE in -Y"
+        assert pose_neg[1] > home[1], "Negative pan should move EE in +Y"
+        # X/Z should change less than Y
+        assert abs(pose_pos[1] - home[1]) > abs(pose_pos[0] - home[0])
+
+    def test_shoulder_lift_moves_z(self):
+        """Shoulder lift should move the EE up/down (±Z)."""
+        chain = so101_chain()
+        home = chain.forward_kinematics(np.zeros(5))
+        q_neg = np.array([0, -0.3, 0, 0, 0])
+        pose_neg = chain.forward_kinematics(q_neg)
+        # Negative lift → higher Z (arm lifts)
+        assert pose_neg[2] > home[2], "Negative lift should raise EE"
+
     def test_fk_returns_ee_pose(self):
         chain = so101_chain()
         pose = chain.forward_kinematics(np.zeros(5))

--- a/tests/test_kinematics/test_robot_chains.py
+++ b/tests/test_kinematics/test_robot_chains.py
@@ -35,7 +35,7 @@ class TestSO101Chain:
         # Expected from URDF: arm extended forward in +X, raised in +Z.
         np.testing.assert_allclose(pos[0], 0.391, atol=0.005)  # ~0.39 m forward
         assert pos[0] > 0.3, "Home x must be positive (arm forward)"
-        np.testing.assert_allclose(pos[1], 0.0, atol=0.005)    # centred in Y
+        np.testing.assert_allclose(pos[1], 0.0, atol=0.005)  # centred in Y
         np.testing.assert_allclose(pos[2], 0.227, atol=0.005)  # ~0.23 m high
 
     def test_fk_home_all_axes_z(self):

--- a/tests/test_kinematics/test_transforms.py
+++ b/tests/test_kinematics/test_transforms.py
@@ -1,0 +1,87 @@
+"""Tests for robopy.kinematics.transforms."""
+
+import numpy as np
+import pytest
+
+from robopy.kinematics.transforms import (
+    pose_from_matrix,
+    rot_x,
+    rot_y,
+    rot_z,
+    translation,
+)
+
+
+class TestRotationMatrices:
+    """Basic properties of rotation matrices."""
+
+    @pytest.mark.parametrize("rot_fn", [rot_x, rot_y, rot_z])
+    def test_identity_at_zero(self, rot_fn):
+        np.testing.assert_allclose(rot_fn(0.0), np.eye(4), atol=1e-15)
+
+    @pytest.mark.parametrize("rot_fn", [rot_x, rot_y, rot_z])
+    def test_orthogonality(self, rot_fn):
+        R = rot_fn(0.7)[:3, :3]
+        np.testing.assert_allclose(R @ R.T, np.eye(3), atol=1e-14)
+
+    @pytest.mark.parametrize("rot_fn", [rot_x, rot_y, rot_z])
+    def test_determinant_is_one(self, rot_fn):
+        R = rot_fn(1.2)[:3, :3]
+        assert abs(np.linalg.det(R) - 1.0) < 1e-14
+
+    def test_rot_x_90(self):
+        T = rot_x(np.pi / 2)
+        # Y-axis → Z-axis, Z-axis → -Y-axis
+        np.testing.assert_allclose(T[:3, :3] @ [0, 1, 0], [0, 0, 1], atol=1e-14)
+        np.testing.assert_allclose(T[:3, :3] @ [0, 0, 1], [0, -1, 0], atol=1e-14)
+
+    def test_rot_y_90(self):
+        T = rot_y(np.pi / 2)
+        # Z-axis → X-axis, X-axis → -Z-axis... actually:
+        # rot_y: X→Z component positive, Z→-X
+        np.testing.assert_allclose(T[:3, :3] @ [1, 0, 0], [0, 0, -1], atol=1e-14)
+        np.testing.assert_allclose(T[:3, :3] @ [0, 0, 1], [1, 0, 0], atol=1e-14)
+
+    def test_rot_z_90(self):
+        T = rot_z(np.pi / 2)
+        np.testing.assert_allclose(T[:3, :3] @ [1, 0, 0], [0, 1, 0], atol=1e-14)
+        np.testing.assert_allclose(T[:3, :3] @ [0, 1, 0], [-1, 0, 0], atol=1e-14)
+
+
+class TestTranslation:
+    def test_basic(self):
+        T = translation(1.0, 2.0, 3.0)
+        assert T.shape == (4, 4)
+        np.testing.assert_allclose(T[:3, 3], [1.0, 2.0, 3.0])
+        np.testing.assert_allclose(T[:3, :3], np.eye(3))
+
+    def test_zero(self):
+        np.testing.assert_allclose(translation(0, 0, 0), np.eye(4))
+
+
+class TestPoseFromMatrix:
+    def test_identity(self):
+        pose = pose_from_matrix(np.eye(4))
+        np.testing.assert_allclose(pose, [0, 0, 0, 0, 0], atol=1e-14)
+
+    def test_pure_translation(self):
+        T = translation(0.1, 0.2, 0.3)
+        pose = pose_from_matrix(T)
+        np.testing.assert_allclose(pose[:3], [0.1, 0.2, 0.3])
+        np.testing.assert_allclose(pose[3:], [0, 0], atol=1e-14)
+
+    def test_pitch_only(self):
+        # Pitch = rotation about Y-axis
+        angle = 0.5
+        T = rot_y(angle)
+        pose = pose_from_matrix(T)
+        np.testing.assert_allclose(pose[3], angle, atol=1e-14)  # pitch
+        np.testing.assert_allclose(pose[4], 0.0, atol=1e-14)  # roll
+
+    def test_roll_only(self):
+        # Roll = rotation about X-axis
+        angle = 0.3
+        T = rot_x(angle)
+        pose = pose_from_matrix(T)
+        np.testing.assert_allclose(pose[3], 0.0, atol=1e-14)  # pitch
+        np.testing.assert_allclose(pose[4], angle, atol=1e-14)  # roll

--- a/tests/test_so101.py
+++ b/tests/test_so101.py
@@ -1,0 +1,33 @@
+
+from robopy.config.robot_config.so101_config import So101Config
+from robopy.robots.so101.so101_robot import So101Robot
+
+
+
+
+def main() -> None:
+    try:
+        # Leader付き設定（テレオペレーション用）
+        config = So101Config(
+            leader_port="/dev/tty.usbmodem5AA90170791",
+            follower_port="/dev/tty.usbmodem5AA90174481",
+            calibration_path="calibration/so101_calib.json",
+        )
+
+        robot = So101Robot(config)
+
+        # 接続（初回はキャリブレーションが実行されます）
+        robot.connect()
+
+        # テレオペレーション（10秒間）
+        robot.teleoperation(max_seconds=10)
+
+    except Exception as e:
+        print(f"エラーが発生しました: {e}")
+
+    finally:
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_so101.py
+++ b/tests/test_so101.py
@@ -1,8 +1,5 @@
-
 from robopy.config.robot_config.so101_config import So101Config
 from robopy.robots.so101.so101_robot import So101Robot
-
-
 
 
 def main() -> None:

--- a/tests/test_so101_spacemouse.py
+++ b/tests/test_so101_spacemouse.py
@@ -1,0 +1,35 @@
+from robopy.config.input_config.spacemouse_config import SpaceMouseConfig
+from robopy.config.robot_config.so101_config import So101Config
+from robopy.robots.so101.so101_robot import So101Robot
+from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+# Followerのみの設定（Leaderアーム不要）
+config = So101Config(
+    follower_port="/dev/tty.usbmodem5AA90174481",
+    calibration_path="calibration/so101_calib.json",
+)
+
+# SpaceMouseの速度をカスタマイズ
+spacemouse_config = SpaceMouseConfig(
+    linear_speed=0.25,   # 並進速度: 0.15 m/s (デフォルト: 0.10)
+    angular_speed=0.8,   # 回転速度: 0.8 rad/s (デフォルト: 0.5)
+    gripper_speed=80.0,  # グリッパー速度: 80 deg/s (デフォルト: 50.0)
+    deadzone=0.05,       # デッドゾーン (デフォルト: 0.05)
+    control_hz=50,       # 制御周波数: 50 Hz (デフォルト: 50)
+)
+
+robot = So101Robot(cfg=config)
+controller = So101SpaceMouseController(robot, spacemouse_config=spacemouse_config)
+
+try:
+    # ロボット接続 + SpaceMouse起動
+    controller.connect()
+
+    # SpaceMouseで30秒間テレオペレーション
+    controller.teleoperation(max_seconds=30)
+
+    # 時間制限なし（Ctrl+C で停止）
+    # controller.teleoperation()
+
+finally:
+    controller.disconnect()

--- a/tests/test_so101_spacemouse.py
+++ b/tests/test_so101_spacemouse.py
@@ -11,11 +11,11 @@ config = So101Config(
 
 # SpaceMouseの速度をカスタマイズ
 spacemouse_config = SpaceMouseConfig(
-    linear_speed=0.25,   # 並進速度: 0.15 m/s (デフォルト: 0.10)
-    angular_speed=0.8,   # 回転速度: 0.8 rad/s (デフォルト: 0.5)
+    linear_speed=0.25,  # 並進速度: 0.15 m/s (デフォルト: 0.10)
+    angular_speed=0.8,  # 回転速度: 0.8 rad/s (デフォルト: 0.5)
     gripper_speed=80.0,  # グリッパー速度: 80 deg/s (デフォルト: 50.0)
-    deadzone=0.05,       # デッドゾーン (デフォルト: 0.05)
-    control_hz=50,       # 制御周波数: 50 Hz (デフォルト: 50)
+    deadzone=0.05,  # デッドゾーン (デフォルト: 0.05)
+    control_hz=50,  # 制御周波数: 50 Hz (デフォルト: 50)
 )
 
 robot = So101Robot(cfg=config)

--- a/tests/test_spacemouse/conftest.py
+++ b/tests/test_spacemouse/conftest.py
@@ -1,0 +1,48 @@
+"""Conftest: stub hardware-only modules that cannot be installed in test env.
+
+This must execute before any robopy submodule is imported, because the import
+chain (robopy.config -> sensors -> hardware SDKs) pulls in native dependencies
+that may not be available in the CI / test environment.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+
+def _ensure_mock(module_name: str) -> None:
+    """Add a MagicMock module to sys.modules if it cannot be imported."""
+    if module_name in sys.modules:
+        return
+    try:
+        __import__(module_name)
+    except (ImportError, ModuleNotFoundError):
+        sys.modules[module_name] = MagicMock()
+
+
+# Everything that might be missing on a minimal test runner
+_STUBS = [
+    "digit_interface",
+    "pyaudio",
+    "feetech_servo_sdk",
+    "pyrealsense2",
+    "dynamixel_sdk",
+    "dynamixel_sdk.robotis_def",
+    "pyspacemouse",
+    "librosa",
+    "serial",
+    "serial.tools",
+    "serial.tools.list_ports",
+    "blosc2",
+    "imageio",
+    "imageio.v2",
+    "scservo_sdk",
+]
+
+for _mod in _STUBS:
+    _ensure_mock(_mod)
+
+# Python 3.11 doesn't have typing.override (added in 3.12)
+import typing as _typing
+
+if not hasattr(_typing, "override"):
+    _typing.override = lambda fn: fn  # type: ignore[attr-defined]

--- a/tests/test_spacemouse/conftest.py
+++ b/tests/test_spacemouse/conftest.py
@@ -6,6 +6,7 @@ that may not be available in the CI / test environment.
 """
 
 import sys
+import typing as _typing
 from unittest.mock import MagicMock
 
 
@@ -42,7 +43,5 @@ for _mod in _STUBS:
     _ensure_mock(_mod)
 
 # Python 3.11 doesn't have typing.override (added in 3.12)
-import typing as _typing
-
 if not hasattr(_typing, "override"):
     _typing.override = lambda fn: fn  # type: ignore[attr-defined]

--- a/tests/test_spacemouse/test_spacemouse_controller.py
+++ b/tests/test_spacemouse/test_spacemouse_controller.py
@@ -1,0 +1,376 @@
+"""Tests for So101SpaceMouseController (mocked hardware)."""
+
+from __future__ import annotations
+
+import sys
+import time
+from collections import namedtuple
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import numpy as np
+import pytest
+
+from robopy.config.input_config.spacemouse_config import SpaceMouseConfig
+from robopy.input.spacemouse import SpaceMouseReader, SpaceMouseState
+from robopy.kinematics import EEPose, IKResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_reader(
+    state: SpaceMouseState | None = None,
+) -> MagicMock:
+    """Create a mock SpaceMouseReader."""
+    reader = MagicMock(spec=SpaceMouseReader)
+    reader.is_running = True
+    if state is None:
+        state = SpaceMouseState()
+    reader.get_state.return_value = state
+    return reader
+
+
+def _mock_robot(
+    follower_joints: np.ndarray | None = None,
+) -> MagicMock:
+    """Create a mock So101Robot with FK/IK support."""
+    if follower_joints is None:
+        follower_joints = np.zeros(6, dtype=np.float32)
+
+    robot = MagicMock()
+    robot.is_connected = True
+
+    # get_arm_observation → ArmObs.follower
+    arm_obs = MagicMock()
+    arm_obs.follower = follower_joints
+    robot.get_arm_observation.return_value = arm_obs
+
+    # forward_kinematics (classmethod → just use a normal return)
+    robot.forward_kinematics = MagicMock(
+        return_value=EEPose(x=0.0, y=0.0, z=0.2, pitch=0.0, roll=0.0)
+    )
+
+    # inverse_kinematics → IKResult
+    def _ik(target, current, ik_config=None):
+        return IKResult(
+            joint_angles_rad=np.deg2rad(current[:5].astype(np.float64)),
+            success=True,
+            iterations=5,
+            position_error=1e-5,
+            orientation_error=1e-5,
+        )
+
+    robot.inverse_kinematics = MagicMock(side_effect=_ik)
+    robot.send_frame_action = MagicMock()
+    robot.sensors_observation = MagicMock(return_value={})
+
+    return robot
+
+
+# ---------------------------------------------------------------------------
+# SpaceMouseConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceMouseConfig:
+    def test_defaults(self) -> None:
+        cfg = SpaceMouseConfig()
+        assert cfg.linear_speed == 0.10
+        assert cfg.angular_speed == 0.5
+        assert cfg.gripper_speed == 50.0
+        assert cfg.deadzone == 0.05
+        assert cfg.control_hz == 50
+
+    def test_custom(self) -> None:
+        cfg = SpaceMouseConfig(linear_speed=0.2, deadzone=0.1)
+        assert cfg.linear_speed == 0.2
+        assert cfg.deadzone == 0.1
+
+
+# ---------------------------------------------------------------------------
+# _apply_deadzone
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDeadzone:
+    def test_below_deadzone(self) -> None:
+        from robopy.robots.so101.so101_spacemouse import _apply_deadzone
+
+        assert _apply_deadzone(0.03, 0.05) == 0.0
+        assert _apply_deadzone(-0.03, 0.05) == 0.0
+
+    def test_above_deadzone(self) -> None:
+        from robopy.robots.so101.so101_spacemouse import _apply_deadzone
+
+        assert _apply_deadzone(0.5, 0.05) == 0.5
+        assert _apply_deadzone(-0.5, 0.05) == -0.5
+
+    def test_at_deadzone(self) -> None:
+        from robopy.robots.so101.so101_spacemouse import _apply_deadzone
+
+        assert _apply_deadzone(0.05, 0.05) == 0.05
+        assert _apply_deadzone(0.04999, 0.05) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# So101SpaceMouseController._control_step
+# ---------------------------------------------------------------------------
+
+
+class TestControlStep:
+    def test_zero_input_no_movement(self) -> None:
+        """When SpaceMouse is centred, EE target should not change."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig()
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState())  # all zeros
+
+        target_ee = np.array([0.0, 0.0, 0.2, 0.0, 0.0], dtype=np.float64)
+        gripper = 50.0
+        joints = np.zeros(6, dtype=np.float32)
+
+        new_ee, new_grip, new_joints = ctrl._control_step(target_ee, gripper, joints, dt=0.02)
+
+        np.testing.assert_allclose(new_ee, target_ee, atol=1e-10)
+        assert new_grip == pytest.approx(50.0)
+        robot.send_frame_action.assert_called_once()
+
+    def test_positive_x_input(self) -> None:
+        """Full positive x should advance target_ee[0]."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig(linear_speed=0.10, deadzone=0.0)
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState(x=1.0))
+
+        target_ee = np.array([0.0, 0.0, 0.2, 0.0, 0.0], dtype=np.float64)
+        dt = 0.02  # 50 Hz
+
+        new_ee, _, _ = ctrl._control_step(target_ee.copy(), 0.0, np.zeros(6, dtype=np.float32), dt)
+
+        expected_dx = 1.0 * 0.10 * 0.02  # 0.002 m
+        assert abs(new_ee[0] - expected_dx) < 1e-10
+        assert abs(new_ee[1]) < 1e-10  # y unchanged
+        assert abs(new_ee[2] - 0.2) < 1e-10  # z unchanged
+
+    def test_button_gripper_close(self) -> None:
+        """Left button should decrease gripper angle."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig(gripper_speed=50.0, deadzone=0.0)
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState(buttons=[True, False]))
+
+        target_ee = np.zeros(5, dtype=np.float64)
+        dt = 0.02
+
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 50.0, np.zeros(6, dtype=np.float32), dt)
+
+        expected = 50.0 - 50.0 * 0.02  # 49.0
+        assert new_grip == pytest.approx(expected)
+
+    def test_button_gripper_open(self) -> None:
+        """Right button should increase gripper angle."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig(gripper_speed=50.0, deadzone=0.0)
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState(buttons=[False, True]))
+
+        target_ee = np.zeros(5, dtype=np.float64)
+        dt = 0.02
+
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 50.0, np.zeros(6, dtype=np.float32), dt)
+
+        expected = 50.0 + 50.0 * 0.02  # 51.0
+        assert new_grip == pytest.approx(expected)
+
+    def test_gripper_clamp_min(self) -> None:
+        """Gripper should not go below 0."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig(gripper_speed=1000.0, deadzone=0.0)
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState(buttons=[True, False]))
+
+        target_ee = np.zeros(5, dtype=np.float64)
+
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 1.0, np.zeros(6, dtype=np.float32), 0.02)
+
+        assert new_grip >= 0.0
+
+    def test_gripper_clamp_max(self) -> None:
+        """Gripper should not exceed 100."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig(gripper_speed=1000.0, deadzone=0.0)
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState(buttons=[False, True]))
+
+        target_ee = np.zeros(5, dtype=np.float64)
+
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 99.0, np.zeros(6, dtype=np.float32), 0.02)
+
+        assert new_grip <= 100.0
+
+    def test_angular_input(self) -> None:
+        """Pitch and roll inputs should move target orientation."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig(angular_speed=0.5, deadzone=0.0)
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState(pitch=1.0, roll=-1.0))
+
+        target_ee = np.zeros(5, dtype=np.float64)
+        dt = 0.02
+
+        new_ee, _, _ = ctrl._control_step(target_ee.copy(), 0.0, np.zeros(6, dtype=np.float32), dt)
+
+        expected_dpitch = 1.0 * 0.5 * 0.02
+        expected_droll = -1.0 * 0.5 * 0.02
+        assert abs(new_ee[3] - expected_dpitch) < 1e-10
+        assert abs(new_ee[4] - expected_droll) < 1e-10
+
+    def test_deadzone_filters_small_inputs(self) -> None:
+        """Inputs below the deadzone should be zeroed."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        cfg = SpaceMouseConfig(deadzone=0.1)
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = cfg
+        ctrl._reader = _mock_reader(SpaceMouseState(x=0.05, y=0.09, z=-0.08))
+
+        target_ee = np.zeros(5, dtype=np.float64)
+        dt = 0.02
+
+        new_ee, _, _ = ctrl._control_step(target_ee.copy(), 0.0, np.zeros(6, dtype=np.float32), dt)
+
+        np.testing.assert_allclose(new_ee, np.zeros(5), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Teleoperation integration
+# ---------------------------------------------------------------------------
+
+
+class TestTeleoperation:
+    def test_not_connected_raises(self) -> None:
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        robot.is_connected = False
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = SpaceMouseConfig()
+        reader = _mock_reader()
+        reader.is_running = False
+        ctrl._reader = reader
+
+        with pytest.raises(ConnectionError):
+            ctrl.teleoperation(max_seconds=1.0)
+
+    def test_timed_teleoperation(self) -> None:
+        """Timed teleoperation should exit after max_seconds."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = SpaceMouseConfig(control_hz=100)
+        ctrl._reader = _mock_reader()
+
+        start = time.perf_counter()
+        ctrl.teleoperation(max_seconds=0.15)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 1.0  # should not take more than 1s
+        assert robot.send_frame_action.call_count > 0
+
+
+# ---------------------------------------------------------------------------
+# record_parallel
+# ---------------------------------------------------------------------------
+
+
+class TestRecordParallel:
+    def test_invalid_max_frame(self) -> None:
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = SpaceMouseConfig()
+        ctrl._reader = _mock_reader()
+
+        with pytest.raises(ValueError, match="max_frame"):
+            ctrl.record_parallel(max_frame=0)
+
+    def test_invalid_fps(self) -> None:
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = SpaceMouseConfig()
+        ctrl._reader = _mock_reader()
+
+        with pytest.raises(ValueError, match="fps"):
+            ctrl.record_parallel(max_frame=10, fps=0)
+
+    def test_record_returns_so101_obs(self) -> None:
+        """A short recording should return valid So101Obs."""
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = SpaceMouseConfig(control_hz=200)
+        ctrl._reader = _mock_reader()
+
+        obs = ctrl.record_parallel(max_frame=3, fps=30, control_hz=200)
+
+        assert obs.arms.leader.shape[0] == 3
+        assert obs.arms.follower.shape[0] == 3
+        assert obs.arms.leader.shape[1] == 6  # 5 joints + gripper
+        assert isinstance(obs.cameras, dict)
+
+    def test_record_not_connected(self) -> None:
+        from robopy.robots.so101.so101_spacemouse import So101SpaceMouseController
+
+        robot = _mock_robot()
+        robot.is_connected = False
+        ctrl = So101SpaceMouseController.__new__(So101SpaceMouseController)
+        ctrl._robot = robot
+        ctrl._sm_config = SpaceMouseConfig()
+        reader = _mock_reader()
+        reader.is_running = False
+        ctrl._reader = reader
+
+        with pytest.raises(ConnectionError):
+            ctrl.record_parallel(max_frame=5)

--- a/tests/test_spacemouse/test_spacemouse_controller.py
+++ b/tests/test_spacemouse/test_spacemouse_controller.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 import time
-from collections import namedtuple
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -13,7 +11,6 @@ import pytest
 from robopy.config.input_config.spacemouse_config import SpaceMouseConfig
 from robopy.input.spacemouse import SpaceMouseReader, SpaceMouseState
 from robopy.kinematics import EEPose, IKResult
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -152,7 +149,7 @@ class TestControlStep:
         gripper = 50.0
         joints = np.zeros(6, dtype=np.float32)
 
-        new_ee, new_grip, new_joints = ctrl._control_step(target_ee, gripper, joints, dt=0.02)
+        new_ee, new_grip, _ = ctrl._control_step(target_ee, gripper, joints, dt=0.02)
 
         np.testing.assert_allclose(new_ee, target_ee, atol=1e-10)
         assert new_grip == pytest.approx(50.0)
@@ -183,7 +180,8 @@ class TestControlStep:
         target_ee = np.zeros(5, dtype=np.float64)
         dt = 0.02
 
-        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 50.0, np.zeros(6, dtype=np.float32), dt)
+        joints = np.zeros(6, dtype=np.float32)
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 50.0, joints, dt)
 
         expected = 50.0 - 50.0 * 0.02  # 49.0
         assert new_grip == pytest.approx(expected)
@@ -197,7 +195,8 @@ class TestControlStep:
         target_ee = np.zeros(5, dtype=np.float64)
         dt = 0.02
 
-        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 50.0, np.zeros(6, dtype=np.float32), dt)
+        joints = np.zeros(6, dtype=np.float32)
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 50.0, joints, dt)
 
         expected = 50.0 + 50.0 * 0.02  # 51.0
         assert new_grip == pytest.approx(expected)
@@ -210,7 +209,8 @@ class TestControlStep:
 
         target_ee = np.zeros(5, dtype=np.float64)
 
-        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 1.0, np.zeros(6, dtype=np.float32), 0.02)
+        joints = np.zeros(6, dtype=np.float32)
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 1.0, joints, 0.02)
 
         assert new_grip >= 0.0
 
@@ -222,7 +222,8 @@ class TestControlStep:
 
         target_ee = np.zeros(5, dtype=np.float64)
 
-        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 99.0, np.zeros(6, dtype=np.float32), 0.02)
+        joints = np.zeros(6, dtype=np.float32)
+        _, new_grip, _ = ctrl._control_step(target_ee.copy(), 99.0, joints, 0.02)
 
         assert new_grip <= 100.0
 

--- a/tests/test_spacemouse/test_spacemouse_reader.py
+++ b/tests/test_spacemouse/test_spacemouse_reader.py
@@ -1,0 +1,180 @@
+"""Tests for SpaceMouseReader and SpaceMouseState."""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from collections import namedtuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robopy.input.spacemouse import SpaceMouseReader, SpaceMouseState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RawState = namedtuple(
+    "_RawState", ["x", "y", "z", "roll", "pitch", "yaw", "buttons", "t"]
+)
+
+
+def _make_mock_pyspacemouse(
+    raw_state: _RawState | None = None,
+    open_success: bool = True,
+) -> MagicMock:
+    """Create a mock ``pyspacemouse`` module."""
+    mock = MagicMock()
+    mock.open.return_value = open_success
+
+    if raw_state is None:
+        raw_state = _RawState(0.1, -0.2, 0.3, 0.4, -0.5, 0.6, [1, 0], 0.0)
+    mock.read.return_value = raw_state
+    mock.close.return_value = None
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# SpaceMouseState
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceMouseState:
+    def test_default_state(self) -> None:
+        s = SpaceMouseState()
+        assert s.x == 0.0
+        assert s.y == 0.0
+        assert s.z == 0.0
+        assert s.roll == 0.0
+        assert s.pitch == 0.0
+        assert s.yaw == 0.0
+        assert s.buttons == [False, False]
+        assert s.timestamp == 0.0
+
+    def test_custom_state(self) -> None:
+        s = SpaceMouseState(x=0.5, y=-0.3, z=1.0, roll=0.1, pitch=-0.2, yaw=0.8)
+        assert s.x == 0.5
+        assert s.y == -0.3
+        assert s.z == 1.0
+
+
+# ---------------------------------------------------------------------------
+# SpaceMouseReader
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceMouseReader:
+    def test_start_imports_pyspacemouse(self) -> None:
+        """start() should raise ImportError when pyspacemouse is missing."""
+        # Temporarily ensure pyspacemouse is not available
+        with patch.dict(sys.modules, {"pyspacemouse": None}):
+            reader = SpaceMouseReader()
+            with pytest.raises(ImportError, match="pyspacemouse"):
+                reader.start()
+
+    def test_start_stop_lifecycle(self) -> None:
+        mock_psm = _make_mock_pyspacemouse()
+        with patch.dict(sys.modules, {"pyspacemouse": mock_psm}):
+            reader = SpaceMouseReader()
+            assert not reader.is_running
+
+            reader.start()
+            assert reader.is_running
+            mock_psm.open.assert_called_once()
+
+            # Let the poll loop run a few cycles
+            time.sleep(0.05)
+
+            reader.stop()
+            assert not reader.is_running
+
+    def test_start_open_failure(self) -> None:
+        mock_psm = _make_mock_pyspacemouse(open_success=False)
+        with patch.dict(sys.modules, {"pyspacemouse": mock_psm}):
+            reader = SpaceMouseReader()
+            with pytest.raises(RuntimeError, match="Failed to open"):
+                reader.start()
+            assert not reader.is_running
+
+    def test_double_start(self) -> None:
+        mock_psm = _make_mock_pyspacemouse()
+        with patch.dict(sys.modules, {"pyspacemouse": mock_psm}):
+            reader = SpaceMouseReader()
+            reader.start()
+            reader.start()  # should just warn
+            assert mock_psm.open.call_count == 1
+            reader.stop()
+
+    def test_get_state_returns_latest(self) -> None:
+        raw = _RawState(0.1, -0.2, 0.3, 0.4, -0.5, 0.6, [1, 0], 0.0)
+        mock_psm = _make_mock_pyspacemouse(raw_state=raw)
+        with patch.dict(sys.modules, {"pyspacemouse": mock_psm}):
+            reader = SpaceMouseReader()
+            reader.start()
+            time.sleep(0.05)
+
+            state = reader.get_state()
+            assert abs(state.x - 0.1) < 1e-6
+            assert abs(state.y - (-0.2)) < 1e-6
+            assert abs(state.z - 0.3) < 1e-6
+            assert abs(state.roll - 0.4) < 1e-6
+            assert abs(state.pitch - (-0.5)) < 1e-6
+            assert abs(state.yaw - 0.6) < 1e-6
+            assert state.buttons == [True, False]
+            assert state.timestamp > 0
+
+            reader.stop()
+
+    def test_get_state_before_start(self) -> None:
+        """get_state() should return defaults before start."""
+        reader = SpaceMouseReader()
+        state = reader.get_state()
+        assert state.x == 0.0
+        assert state.buttons == [False, False]
+
+    def test_get_state_returns_copy(self) -> None:
+        """Successive calls should return independent objects."""
+        mock_psm = _make_mock_pyspacemouse()
+        with patch.dict(sys.modules, {"pyspacemouse": mock_psm}):
+            reader = SpaceMouseReader()
+            reader.start()
+            time.sleep(0.05)
+
+            s1 = reader.get_state()
+            s2 = reader.get_state()
+            assert s1 is not s2
+            assert s1.buttons is not s2.buttons
+
+            reader.stop()
+
+    def test_buttons_empty(self) -> None:
+        """Handle devices that report no buttons."""
+        raw = _RawState(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, [], 0.0)
+        mock_psm = _make_mock_pyspacemouse(raw_state=raw)
+        with patch.dict(sys.modules, {"pyspacemouse": mock_psm}):
+            reader = SpaceMouseReader()
+            reader.start()
+            time.sleep(0.05)
+
+            state = reader.get_state()
+            assert state.buttons == [False, False]
+
+            reader.stop()
+
+    def test_buttons_no_attr(self) -> None:
+        """Handle raw state objects without a buttons attribute."""
+        RawNoButtons = namedtuple("RawNoButtons", ["x", "y", "z", "roll", "pitch", "yaw", "t"])
+        raw = RawNoButtons(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        mock_psm = _make_mock_pyspacemouse(raw_state=raw)
+        with patch.dict(sys.modules, {"pyspacemouse": mock_psm}):
+            reader = SpaceMouseReader()
+            reader.start()
+            time.sleep(0.05)
+
+            state = reader.get_state()
+            assert state.buttons == [False, False]
+
+            reader.stop()

--- a/tests/test_spacemouse/test_spacemouse_reader.py
+++ b/tests/test_spacemouse/test_spacemouse_reader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 import time
-import types
 from collections import namedtuple
 from unittest.mock import MagicMock, patch
 
@@ -12,18 +11,15 @@ import pytest
 
 from robopy.input.spacemouse import SpaceMouseReader, SpaceMouseState
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-_RawState = namedtuple(
-    "_RawState", ["x", "y", "z", "roll", "pitch", "yaw", "buttons", "t"]
-)
+_RawState = namedtuple("_RawState", ["x", "y", "z", "roll", "pitch", "yaw", "buttons", "t"])
 
 
 def _make_mock_pyspacemouse(
-    raw_state: _RawState | None = None,
+    raw_state: object | None = None,
     open_success: bool = True,
 ) -> MagicMock:
     """Create a mock ``pyspacemouse`` module."""

--- a/uv.lock
+++ b/uv.lock
@@ -443,6 +443,15 @@ wheels = [
 ]
 
 [[package]]
+name = "feetech-servo-sdk"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyserial" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz", hash = "sha256:d4d3832e4b1b22a8222133a414db9f868224c2fb639426a1b11d96ddfe84e69c", size = 8392, upload-time = "2022-11-08T03:44:45.269Z" }
+
+[[package]]
 name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1777,6 +1786,7 @@ dependencies = [
     { name = "blosc2" },
     { name = "digit-interface" },
     { name = "dynamixel-sdk" },
+    { name = "feetech-servo-sdk" },
     { name = "h5py" },
     { name = "imageio" },
     { name = "librosa" },
@@ -1816,6 +1826,7 @@ requires-dist = [
     { name = "blosc2", specifier = ">=3.8.0" },
     { name = "digit-interface", specifier = ">=0.2.1" },
     { name = "dynamixel-sdk", specifier = ">=3.7.31" },
+    { name = "feetech-servo-sdk", specifier = ">=1.0.0" },
     { name = "h5py", specifier = ">=3.15.1" },
     { name = "imageio", specifier = ">=2.37.0" },
     { name = "librosa", specifier = ">=0.11.0" },


### PR DESCRIPTION
## Summary
- Fix ruff lint errors: line-too-long (E501), unused variables/imports (F841, F401), import ordering (E402, I001), f-string issues (F541), whitespace (E226)
- Apply ruff-format to all files that needed reformatting
- Fix mypy type errors: widen `_make_mock_pyspacemouse` param type for `RawNoButtons` compatibility, cast `float64` to `float32` for `inverse_kinematics` call

## Test plan
- [ ] Verify `uv run pre-commit run --all-files` passes in CI
- [ ] Verify ruff, ruff-format, and mypy hooks all pass

https://claude.ai/code/session_01P6E17Ga3FKtgVkaidiR3RC